### PR TITLE
Make sure a directory is created for each simulation

### DIFF
--- a/source/run_libensemble.py
+++ b/source/run_libensemble.py
@@ -163,6 +163,8 @@ elif generator_type == 'aposmm':
 # Save H to file every N simulation evaluations
 libE_specs['save_every_k_sims'] = 5
 libE_specs['sim_dir_copy_files'] = ['sim_specific/template_fbpic_script.py']
+# Force libEnsemble to create a directory for each simulation
+libE_specs['sim_dirs_make'] = True
 
 exit_criteria = {'sim_max': sim_max}  # Exit after running sim_max simulations
 


### PR DESCRIPTION
In the latest libEnsemble version, it seems that the default behavior on whether to create a folder for each simulation has changed. This is because the `'sim_dirs_make'` parameter of `libE_specs`, is now now `False` by default.

This PR now explicitly sets this parameter to `True` so that the default value is not used. This makes sure that a separate folder is created for each simulation, as it used to be.