### PR TITLE
Use multi-fidelity methods by default, for multi-fidelity examples

### DIFF
--- a/examples/dummy_mf/run_example.py
+++ b/examples/dummy_mf/run_example.py
@@ -6,7 +6,7 @@ from analysis_script import analyze_simulation, analyzed_quantities
 from mf_parameters import mf_parameters
 
 
-gen_type = 'bo'
+gen_type = 'bo_mf'
 sim_max = 10
 sim_template = './template_simulation_script.py'
 run_async = True

--- a/examples/dummy_mf_disc/run_example.py
+++ b/examples/dummy_mf_disc/run_example.py
@@ -6,7 +6,7 @@ from analysis_script import analyze_simulation, analyzed_quantities
 from mf_parameters import mf_parameters
 
 
-gen_type = 'bo'
+gen_type = 'bo_mf_disc'
 sim_max = 10
 sim_template = './template_simulation_script.py'
 run_async = True

--- a/examples/ionization_injection_mf/run_example.py
+++ b/examples/ionization_injection_mf/run_example.py
@@ -6,7 +6,7 @@ from analysis_script import analyze_simulation, analyzed_quantities
 from mf_parameters import mf_parameters
 
 
-gen_type = 'bo'
+gen_type = 'bo_mf'
 sim_max = 10
 sim_template = './template_simulation_script.py'
 run_async = True


### PR DESCRIPTION
This changes the optimization method, in the examples, in order to always use multi-fidelity when possible.