### PR TITLE
Change name of the script in submission scripts

### DIFF
--- a/submission_scripts/juwels
+++ b/submission_scripts/juwels
@@ -19,4 +19,4 @@ export FBPIC_ENABLE_GPUDIRECT=0
 
 export LIBE_SIM_EXTRA_ARGS="--gres=gpu:1"
 
-python run_libensemble.py --comms local --nworkers {n_workers}
+python run_example.py --comms local --nworkers {n_workers}

--- a/submission_scripts/lawrencium
+++ b/submission_scripts/lawrencium
@@ -18,4 +18,4 @@ export OMP_NUM_THREADS=1
 
 export LIBE_SIM_EXTRA_ARGS="--gres=gpu:1"
 
-python run_libensemble.py --comms local --nworkers {n_workers}
+python run_example.py --comms local --nworkers {n_workers}

--- a/submission_scripts/lawrencium_1080ti
+++ b/submission_scripts/lawrencium_1080ti
@@ -18,4 +18,4 @@ export OMP_NUM_THREADS=1
 
 export LIBE_SIM_EXTRA_ARGS="--gres=gpu:1"
 
-python run_libensemble.py --comms local --nworkers {n_workers}
+python run_example.py --comms local --nworkers {n_workers}

--- a/submission_scripts/summit
+++ b/submission_scripts/summit
@@ -24,4 +24,4 @@ export FBPIC_DISABLE_CACHING=1
 
 export LIBE_SIM_EXTRA_ARGS="-n 1 -a 1 -g 1 -c 1 --bind=packed:1"
 
-python run_libensemble.py --comms local --nworkers {n_workers}
+python run_example.py --comms local --nworkers {n_workers}


### PR DESCRIPTION
It seems that the name of the Python script was erroneous in the submission script: the corresponding file was not found.