### PR TITLE
Add automated tests for multi-fidelity cases

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -46,3 +46,15 @@ jobs:
         cd optimization_folder;
         ./create_new_optimization.py --name test --from dummy --machine local --n_sim_workers 2;
         cd test; python run_example.py --comms local --nworkers 3
+    - shell: bash -l {0}
+      name: test dummy_mf example
+      run: |
+        cd optimization_folder;
+        ./create_new_optimization.py --name test_mf --from dummy_mf --machine local --n_sim_workers 2;
+        cd test_mf; python run_example.py --comms local --nworkers 3
+    - shell: bash -l {0}
+      name: test dummy_mf_disc example
+      run: |
+        cd optimization_folder;
+        ./create_new_optimization.py --name test_mf_disc --from dummy_mf_disc --machine local --n_sim_workers 2;
+        cd test_mf_disc; python run_example.py --comms local --nworkers 3

--- a/examples/dummy_mf/mf_parameters.py
+++ b/examples/dummy_mf/mf_parameters.py
@@ -6,5 +6,5 @@ mf_parameters = {
     'name': 'resolution',
     'range': [1, 8],
     'discrete': False,
-    'cost_func': lambda z: z[0]**2
+    'cost_func': lambda z: z[0]
 }

--- a/examples/dummy_mf/template_simulation_script.py
+++ b/examples/dummy_mf/template_simulation_script.py
@@ -8,6 +8,7 @@ import time
 
 # 2D function with multiple minima
 result =  -( {{x0}} + 10*np.cos({{x0}} + 0.1*{{resolution}}) )*( {{x1}} + 5*np.cos({{x1}} - 0.2*{{resolution}}) )
+time.sleep({{resolution}})
 
 with open('result.txt', 'w') as f:
     f.write("%f" %result)

--- a/examples/dummy_mf_disc/mf_parameters.py
+++ b/examples/dummy_mf_disc/mf_parameters.py
@@ -4,7 +4,7 @@ Contains the parameters for multi-fidelity optimization.
 
 mf_parameters = {
     'name': 'resolution',
-    'range': [1, 2, 4, 8],
+    'range': [1, 2, 4],
     'discrete': True,
-    'cost_func': lambda z: int(z[0][0])**2
+    'cost_func': lambda z: z[0][0]
 }

--- a/examples/dummy_mf_disc/template_simulation_script.py
+++ b/examples/dummy_mf_disc/template_simulation_script.py
@@ -8,6 +8,7 @@ import time
 
 # 2D function with multiple minima
 result =  -( {{x0}} + 10*np.cos({{x0}} + 0.1*{{resolution}}) )*( {{x1}} + 5*np.cos({{x1}} - 0.2*{{resolution}}) )
+time.sleep({{resolution}})
 
 with open('result.txt', 'w') as f:
     f.write("%f" %result)


### PR DESCRIPTION
This adds an automated test for the different multi-fidelity cases.

In addition, a `time.sleep` command is added in order to have a realistic resolution-dependent delay.