### PR TITLE
Use proper Python version in CI

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -32,7 +32,7 @@ jobs:
     - shell: bash -l {0}
       name: Install dependencies
       run: |
-        conda install -c conda-forge numpy mpi4py;
+        conda install -c conda-forge python=${{ matrix.python-version }} numpy mpi4py;
         pip3 install pyflakes;
         pip3 install ax-platform;
         pip3 install git+http://github.com/Libensemble/libensemble@develop;


### PR DESCRIPTION
For some reason, Python 3.10 does not seem to install Ax properly...