### PR TITLE
Add multi-model MT example with FBPIC and Wake-T

### DIFF
--- a/examples/multi_model_mt/analysis_script.py
+++ b/examples/multi_model_mt/analysis_script.py
@@ -1,0 +1,107 @@
+import os
+import numpy as np
+import visualpic as vp
+
+
+analyzed_quantities = [
+    ('energy_med', float, (1,)),
+    # Final average energy, in MeV.
+    ('energy_mad', float, (1,)),
+    # Final beam charge.
+    ('charge', float, (1,)),
+]
+
+
+def analyze_simulation( simulation_directory, libE_output ):
+
+    # Load simulation data.
+    dc = vp.DataContainer(
+        'openpmd',
+        os.path.join(simulation_directory, 'diags/hdf5')
+    )
+    dc.load_data()
+
+    # Get bunch charge and longitudinal momentum.
+    bunch = dc.get_species('bunch')
+    ts = bunch.timesteps
+    bunch_data = bunch.get_data(ts[-1], ['pz', 'q'])
+    pz = bunch_data['pz'][0]
+    q = bunch_data['q'][0]
+
+    # Filter out any charge below ~50 MeV.
+    pz_filter = np.where(pz > 100)
+    pz = pz[pz_filter]
+    q = q[pz_filter]
+
+    # Calculate relevant quantities.
+    q_tot = np.abs(np.sum(q)) * 1e12  # pC
+    q_ref = 10  # pC
+    med, mad = weighted_mad(pz* 0.511, q)
+    mad_rel = mad/med
+    med *= 1e-3 # GeV
+    mad_rel_ref = 1e-2
+
+    # Calculate value of objective function.
+    f = np.log(med * q_tot / q_ref / (mad_rel / mad_rel_ref))
+    
+    # Fill output dictionary.
+    libE_output['f'] = -f
+    libE_output['charge'] = q_tot
+    libE_output['energy_med'] = med
+    libE_output['energy_mad'] = mad
+
+    # For convenience, save value of objective to text file.
+    np.savetxt('f.txt', np.array([f]))
+
+    return libE_output
+
+
+def weighted_mad(x, w):
+    med = weighted_median(x,w)
+    mad = weighted_median(np.abs(x-med), w)
+    return med, mad
+
+
+def weighted_median(data, weights):
+    """
+    Compute the weighted quantile of a 1D numpy array.
+    Parameters
+    ----------
+    data : ndarray
+        Input array (one dimension).
+    weights : ndarray
+        Array with the weights of the same size of `data`.
+    quantile : float
+        Quantile to compute. It must have a value between 0 and 1.
+    Returns
+    -------
+    quantile_1D : float
+        The output value.
+    """
+    quantile=.5
+    # Check the data
+    if not isinstance(data, np.matrix):
+        data = np.asarray(data)
+    if not isinstance(weights, np.matrix):
+        weights = np.asarray(weights)
+    nd = data.ndim
+    if nd != 1:
+        raise TypeError("data must be a one dimensional array")
+    ndw = weights.ndim
+    if ndw != 1:
+        raise TypeError("weights must be a one dimensional array")
+    if data.shape != weights.shape:
+        raise TypeError("the length of data and weights must be the same")
+    if ((quantile > 1.) or (quantile < 0.)):
+        raise ValueError("quantile must have a value between 0. and 1.")
+    # Sort the data
+    ind_sorted = np.argsort(data)
+    sorted_data = data[ind_sorted]
+    sorted_weights = weights[ind_sorted]
+    # Compute the auxiliary arrays
+    Sn = np.cumsum(sorted_weights)
+    # TODO: Check that the weights do not sum zero
+    #assert Sn != 0, "The sum of the weights must not be zero"
+    Pn = (Sn-0.5*sorted_weights)/Sn[-1]
+    # Get the value of the weighted median
+    return np.interp(quantile, Pn, sorted_data)

--- a/examples/multi_model_mt/bunch_utils.py
+++ b/examples/multi_model_mt/bunch_utils.py
@@ -1,0 +1,126 @@
+import numpy as np
+from scipy.constants import c
+
+
+def gaussian_bunch(q_tot, n_part, gamma0, s_g, s_z, emit_x, s_x,
+                   zf=0., tf=0, x_c=0.):
+    n_part = int(n_part)
+    
+    np.random.seed(42)
+    z = zf + s_z * np.random.standard_normal(n_part)
+    x = x_c + s_x * np.random.standard_normal(n_part)
+    y = s_x * np.random.standard_normal(n_part)
+        
+    gamma = np.random.normal(gamma0, s_g, n_part)
+
+    s_ux = emit_x / s_x
+    ux = s_ux * np.random.standard_normal(n_part)
+    uy = s_ux * np.random.standard_normal(n_part)
+
+    uz = np.sqrt((gamma ** 2 - 1) - ux ** 2 - uy ** 2)
+
+    if tf != 0.:
+        x = x - ux * c * tf / gamma
+        y = y - uy * c * tf / gamma
+        z = z - uz * c * tf / gamma
+
+    q = np.ones(n_part) * q_tot / n_part
+
+    return x, y, z, ux, uy, uz, q
+    
+
+def flattop_bunch(q_tot, n_part, gamma0, s_g, length, s_z, emit_x, s_x,
+                  emit_y, s_y, zf=0., tf=0, x_c=0., y_c=0):
+    n_part = int(n_part)
+
+    norma = length + np.sqrt(2 * np.pi) * s_z
+    n_plat = int(n_part * length / norma)
+    n_gaus = int(n_part * np.sqrt(2 * np.pi) * s_z / norma)
+
+    # Create flattop and gaussian profiles
+    z_plat = np.random.uniform(0., length, n_plat)
+    z_gaus = s_z * np.random.standard_normal(n_gaus)
+
+    # Concatenate both profiles
+    z = np.concatenate((z_gaus[np.where(z_gaus <= 0)],
+                        z_plat,
+                        z_gaus[np.where(z_gaus > 0)] + length))
+       
+    z = z - length / 2. + zf  # shift to final position
+    
+    n_part = len(z)
+    x = x_c + s_x * np.random.standard_normal(n_part)
+    y = y_c + s_y * np.random.standard_normal(n_part)
+        
+    gamma = np.random.normal(gamma0, s_g, n_part)
+
+    s_ux = emit_x / s_x
+    ux = s_ux * np.random.standard_normal(n_part)
+
+    s_uy = emit_y / s_y
+    uy = s_uy * np.random.standard_normal(n_part)
+
+    uz = np.sqrt((gamma ** 2 - 1) - ux ** 2 - uy ** 2)
+
+    if tf != 0.:
+        x = x - ux * c * tf / gamma
+        y = y - uy * c * tf / gamma
+        z = z - uz * c * tf / gamma
+    
+    q = np.ones(n_part) * q_tot / n_part
+
+    return x, y, z, ux, uy, uz, q
+
+
+def trapezoidal_bunch(i0, i1, n_part, gamma0, s_g, length, s_z, emit_x, s_x,
+                      emit_y, s_y, zf=0., tf=0, x_c=0., y_c=0.):
+    n_part = int(n_part)
+
+    q_plat = (min(i0, i1) / c) * length
+    q_triag = ((max(i0, i1) - min(i0, i1)) / c) * length / 2.
+    q_gaus0 = (i0 / c) * np.sqrt(2 * np.pi) * s_z / 2.
+    q_gaus1 = (i1 / c) * np.sqrt(2 * np.pi) * s_z / 2.
+    q_tot = q_plat + q_triag + q_gaus0 + q_gaus1
+
+    n_plat = int(n_part * q_plat / q_tot)
+    n_triag = int(n_part * q_triag / q_tot)
+    n_gaus0 = int(n_part * q_gaus0 / q_tot)
+    n_gaus1 = int(n_part * q_gaus1 / q_tot)
+
+    np.random.seed(42)
+    z_plat = np.random.uniform(0., length, n_plat)
+    if i0 <= i1:
+        z_triag = np.random.triangular(0., length, length, n_triag)
+    else:
+        z_triag = np.random.triangular(0., 0., length, n_triag)
+    z_gaus0 = s_z * np.random.standard_normal(2 * n_gaus0)
+    z_gaus1 = s_z * np.random.standard_normal(2 * n_gaus1)
+
+    z = np.concatenate((z_gaus0[np.where(z_gaus0 < 0)],
+                        z_plat, z_triag,
+                        z_gaus1[np.where(z_gaus1 > 0)] + length))
+
+    z = z - length / 2. + zf  # shift to final position
+
+    n_part = len(z)
+    x = x_c + s_x * np.random.standard_normal(n_part)
+    y = y_c + s_y * np.random.standard_normal(n_part)
+
+    gamma = np.random.normal(gamma0, s_g, n_part)
+
+    s_ux = emit_x / s_x
+    ux = s_ux * np.random.standard_normal(n_part)
+
+    s_uy = emit_y / s_y
+    uy = s_uy * np.random.standard_normal(n_part)
+
+    uz = np.sqrt((gamma ** 2 - 1) - ux ** 2 - uy ** 2)
+
+    if tf != 0.:
+        x = x - ux * c * tf / gamma
+        y = y - uy * c * tf / gamma
+        z = z - uz * c * tf / gamma
+
+    q = np.ones(n_part) * q_tot / n_part
+
+    return x, y, z, ux, uy, uz, q

--- a/examples/multi_model_mt/custom_fld_diags.py
+++ b/examples/multi_model_mt/custom_fld_diags.py
@@ -1,0 +1,815 @@
+# Copyright 2016, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen
+# License: 3-Clause-BSD-LBNL
+"""
+This file defines the class BackTransformedFieldDiagnostic
+
+Major features:
+- The class reuses the existing methods of FieldDiagnostic
+  as much as possible, through class inheritance
+- The class implements memory buffering of the slices, so as
+  not to write to disk at every timestep
+- Parallel output is not implemented for the moment
+"""
+import os
+import numpy as np
+from scipy.constants import c
+from fbpic.openpmd_diag.field_diag import FieldDiagnostic
+
+# Check if CUDA is available, then import CUDA functions
+from fbpic.utils.cuda import cuda_installed
+if cuda_installed:
+    import cupy
+    from fbpic.utils.cuda import cuda, cuda_tpb_bpg_1d, compile_cupy
+
+class BackTransformedFieldDiagnostic(FieldDiagnostic):
+    """
+    Class that writes the fields *in the lab frame*, from
+    a simulation in the boosted frame
+    """
+    def __init__(self, zmin_lab, zmax_lab, v_lab, t_start_lab, dt_snapshots_lab,
+                 Ntot_snapshots_lab, gamma_boost, period, fldobject,
+                 comm=None, fieldtypes=["E", "B"],
+                 write_dir=None ) :
+        """
+        Initialize diagnostics that retrieve the data in the lab frame,
+        as a series of snapshot (one file per snapshot),
+        within a virtual moving window defined by zmin_lab, zmax_lab, v_lab.
+
+        The parameters defined below are specific to the back-transformed
+        diagnostics. See the documentation of `FieldDiagnostic` for
+        the other parameters.
+
+        Parameters
+        ----------
+        zmin_lab: float (in meters)
+            The position of the left edge of the virtual moving window,
+            *in the lab frame*, at t=0
+        zmax_lab: float (in meters)
+            The position of the right edge of the virtual moving window,
+            *in the lab frame*, at t=0
+
+        v_lab: float (in m.s^-1)
+            Speed of the moving window *in the lab frame*
+
+        dt_snapshots_lab: float (in seconds)
+            Time interval *in the lab frame* between two successive snapshots
+
+        Ntot_snapshots_lab: int
+            Total number of snapshots that this diagnostic will produce
+
+        period: int
+            Number of iterations for which the data is accumulated in memory,
+            before finally writing it to the disk.
+
+        fieldtypes : a list of strings, optional
+            The strings are either "rho", "E", "B" or "J"
+            and indicate which field should be written.
+            Default : only "E" and "B" are written. This is because the
+            backward Lorentz transform is not as precise for "rho" and "J" as
+            for "E" and "B" (because "rho" and "J" are staggered in time).
+            The user can still output "rho" and "J" by changing `fieldtypes`,
+            but has to be aware that there may errors in the backward transform.
+            Moreover, writing rho/J slows down the simulation, as these fields
+            are then brought from spectral to real space, at each iteration.
+        """
+        # Do not leave write_dir as None, as this may conflict with
+        # the default directory ('./diags') in which diagnostics in the
+        # boosted frame are written.
+        if write_dir is None:
+            write_dir='lab_diags'
+
+        # Initialize the normal attributes of a FieldDiagnostic
+        FieldDiagnostic.__init__(self, period, fldobject,
+                                comm, fieldtypes, write_dir)
+
+        # Register the boost quantities
+        self.gamma_boost = gamma_boost
+        self.inv_gamma_boost = 1./gamma_boost
+        self.beta_boost = np.sqrt( 1. - self.inv_gamma_boost**2 )
+        self.inv_beta_boost = 1./self.beta_boost
+
+        # Find the z resolution and size of the diagnostic *in the lab frame*
+        # (Needed to initialize metadata in the openPMD file)
+        dz_lab = c*self.fld.dt * self.inv_beta_boost*self.inv_gamma_boost
+        Nz = int( (zmax_lab - zmin_lab)/dz_lab ) + 1
+        self.inv_dz_lab = 1./dz_lab
+        # Get number of radial cells in the output
+        # (if possible, remove damp cells)
+        if self.comm is None:
+            Nr = self.fld.interp[0].Nr
+        else:
+            Nr = self.comm.get_Nr(with_damp=False)
+
+        # Create the list of LabSnapshot objects
+        self.snapshots = []
+        for i in range( Ntot_snapshots_lab ):
+            t_lab = t_start_lab + i * dt_snapshots_lab
+            snapshot = LabSnapshot( t_lab,
+                                    zmin_lab + v_lab*t_lab,
+                                    zmax_lab + v_lab*t_lab,
+                                    self.write_dir, i, self.fld, Nr )
+            self.snapshots.append( snapshot )
+            # Initialize a corresponding empty file
+            self.create_file_empty_meshes( snapshot.filename, i,
+                snapshot.t_lab, Nr, Nz, snapshot.zmin_lab, dz_lab, self.fld.dt)
+
+        # Create a slice handler, which will do all the extraction, Lorentz
+        # transformation, etc for each slice to be registered in a LabSnapshot
+        self.slice_handler = SliceHandler(self.gamma_boost, self.beta_boost, Nr)
+
+    def write( self, iteration ):
+        """
+        Redefines the method write of the parent class FieldDiagnostic
+        """
+        # At each timestep, store a slices of the fields in memory buffers
+        self.store_snapshot_slices( iteration )
+
+        # Every self.period, write the buffered slices to disk
+        if iteration % self.period == 0:
+            self.flush_to_disk()
+
+    def store_snapshot_slices( self, iteration ):
+        """
+        Store slices of the fields in the memory buffers of the
+        corresponding lab snapshots
+
+        Parameter
+        ---------
+        iteration : int
+            The current iteration in the boosted frame simulation
+        """
+        # If needed: Bring rho/J from spectral space (where they where
+        # smoothed/corrected) to real space
+        if "rho" in self.fieldtypes or "J" in self.fieldtypes:
+            # Get 'rho_prev', since it correspond to rho at time n
+            self.fld.spect2interp('rho_prev')
+            self.fld.spect2interp('J')
+            # Exchange rho and J if needed
+            if (self.comm is not None) and (self.comm.size > 1):
+                if not self.fld.exchanged_source['J']:
+                    self.comm.exchange_fields(self.fld.interp, 'J', 'add')
+                if not self.fld.exchanged_source['rho_prev']:
+                    self.comm.exchange_fields(self.fld.interp, 'rho', 'add')
+
+        # Find the limits of the local subdomain at this iteration
+        if self.comm is None:
+            zmin_boost = self.fld.interp[0].zmin
+            zmax_boost = self.fld.interp[0].zmax
+        else:
+            # If a communicator is provided, remove guard and damp cells
+            zmin_boost, zmax_boost = self.comm.get_zmin_zmax(
+                local=True, with_damp=False, with_guard=False, rank=self.rank )
+
+        # Extract the current time in the boosted frame
+        time = iteration * self.fld.dt
+
+        # Loop through the labsnapshots
+        for snapshot in self.snapshots:
+
+            # Update the positions of the output slice of this snapshot
+            # in the lab and boosted frame (current_z_lab and current_z_boost)
+            snapshot.update_current_output_positions( time,
+                            self.inv_gamma_boost, self.inv_beta_boost )
+
+            # For this snapshot:
+            # - check if the output position *in the boosted frame*
+            #   is in the current local domain
+            # - check if the output position *in the lab frame*
+            #   is within the lab-frame boundaries of the current snapshot
+            if ( (snapshot.current_z_boost > zmin_boost) and \
+                 (snapshot.current_z_boost < zmax_boost) and \
+                 (snapshot.current_z_lab > snapshot.zmin_lab) and \
+                 (snapshot.current_z_lab < snapshot.zmax_lab) ):
+
+                # In this case, extract the proper slice from the field array,
+                # and store the results into snapshot.slice_array
+                # (when running on the GPU, snapshot.slice_array
+                # is a device array)
+                self.slice_handler.extract_slice(
+                    self.fld, self.comm, snapshot.current_z_boost,
+                    zmin_boost, snapshot.slice_array )
+
+                # Register snapshot.slice_array in the list of buffers
+                # (when running on the GPU, the slice to the CPU)
+                snapshot.register_slice( self.inv_dz_lab )
+
+    def flush_to_disk( self ):
+        """
+        Writes the buffered slices of fields to the disk
+
+        Erase the buffered slices of the LabSnapshot objects
+        """
+        # Loop through the labsnapshots and flush the data
+        for snapshot in self.snapshots:
+
+            # Compact the successive slices that have been buffered
+            # over time into a single array, on each proc
+            field_array, iz_min, iz_max = snapshot.compact_slices()
+            # Perform the Lorentz transformation of the field values
+            # *from the boosted frame to the lab frame*, on each proc
+            if field_array is not None:
+                self.slice_handler.transform_fields_to_lab_frame( field_array )
+
+            # Gather the slices on the first proc
+            if self.comm is not None and self.comm.size > 1:
+                global_field_array, global_iz_min, global_iz_max = \
+                    self.gather_slices( field_array, iz_min, iz_max )
+            else:
+                global_field_array = field_array
+                global_iz_min = iz_min
+                global_iz_max = iz_max
+
+            # First proc writes the global array to disk (if it is not empty)
+            if (self.rank==0) and (global_field_array is not None):
+
+                # Write to disk
+                self.write_slices( global_field_array, global_iz_min,
+                    global_iz_max, snapshot, self.slice_handler.field_to_index)
+
+            # Erase the memory buffers
+            snapshot.buffered_slices = []
+            snapshot.buffer_z_indices = []
+
+    def gather_slices( self, field_array, iz_min, iz_max ):
+        """
+        Stitch together the field_array of the different processors
+
+        Parameters:
+        -----------
+        field_array: ndarray of reals, or None
+            If the local proc has no slice data, this is None
+            Otherwise, it is an array of shape (10, 2*Nm-1, Nr, nslice_local)
+
+        iz_min, iz_max: ints or None
+            If the local proc has no slice data, this is None
+            Otherwise, it corresponds to the indices at which the data should
+            written, in final dataset which is on disk
+
+        Returns:
+        --------
+        A tuple with:
+        global_field_array: an array of shape (10, 2*Nm-1, Nr, nslice_global),
+           or None if none of the procs had any data
+        global_izmin, global_izmax: the indices at which the global_field_array
+           should be written (or None)
+        """
+        # Gather objects into lists (one element per proc)
+        # Note: this is slow, as it uses the generic mpi4py routines gather.
+        # (This is because for some proc field_array can be None.)
+        mpi_comm = self.comm.mpi_comm
+        field_array_list = mpi_comm.gather( field_array )
+        iz_min_list = mpi_comm.gather( iz_min )
+        iz_max_list = mpi_comm.gather( iz_max )
+
+        # First proc: merge the results
+        if self.rank == 0:
+
+            # Check whether any processor had some slices
+            no_slices = True
+            for f_array in field_array_list:
+                if f_array is not None:
+                    no_slices = False
+                    n_modes = f_array.shape[1] # n_modes is 2*Nm - 1
+                    Nr = f_array.shape[2]
+
+            # If there are no slices, set global quantities to None
+            if no_slices:
+                global_field_array = None
+                global_iz_min = None
+                global_iz_max = None
+
+            # If there are some slices, gather them
+            else:
+                # Find the global iz_min and global iz_max
+                global_iz_min = min([n for n in iz_min_list if n is not None])
+                global_iz_max = max([n for n in iz_max_list if n is not None])
+
+                # Allocate a the global field array, with the proper size
+                nslice = global_iz_max - global_iz_min
+                data_shape = (10, n_modes, Nr, nslice)
+                global_field_array = np.zeros( data_shape )
+
+                # Loop through all the processors
+                # Fit the field arrays one by one into the global_field_array
+                for i_proc in range(self.comm.size):
+
+                    # If this proc has no data, skip it
+                    if field_array_list[ i_proc ] is None:
+                        continue
+                    # Longitudinal indices within the array global_field_array
+                    s_min = iz_min_list[ i_proc ] - global_iz_min
+                    s_max = iz_max_list[ i_proc ] - global_iz_min
+                    # Copy the array to the proper position
+                    global_field_array[:,:,:, s_min:s_max] = \
+                                                    field_array_list[i_proc]
+
+            # The first proc returns the result
+            return( global_field_array, global_iz_min, global_iz_max )
+
+        # Other processors return a dummy placeholder
+        else:
+            return( None, None, None )
+
+    def write_slices( self, field_array, iz_min, iz_max, snapshot, f2i ):
+        """
+        For one given snapshot, write the slices of the
+        different fields to an openPMD file
+
+        Parameters
+        ----------
+        field_array: array of reals
+            Array of shape (10, 2*Nm-1, Nr, nslices) which contains
+            field values
+
+        iz_min, iz_max: integers
+            The indices between which the slices will be written
+            iz_min is inclusice and iz_max is exclusive
+
+        snapshot: a LabSnaphot object
+
+        f2i: dict
+            Dictionary of correspondance between the field names
+            and the integer index in the field_array
+        """
+        # Open the file without parallel I/O in this implementation
+        f = self.open_file( snapshot.filename )
+
+        field_path = "/data/%d/fields/" %snapshot.iteration
+        field_grp = f[field_path]
+
+        # Loop over the different quantities that should be written
+        for fieldtype in self.fieldtypes:
+            # Scalar field
+            if fieldtype == "rho":
+                data = field_array[ f2i[ "rho" ] ]
+                self.write_field_slices( field_grp, data, "rho",
+                                            iz_min, iz_max )
+            # Vector field
+            elif fieldtype in ["E", "B", "J"]:
+                for coord in self.coords:
+                    quantity = "%s%s" %(fieldtype, coord)
+                    path = "%s/%s" %(fieldtype, coord)
+                    data = field_array[ f2i[ quantity ] ]
+                    self.write_field_slices( field_grp, data, path,
+                                            iz_min, iz_max )
+
+        # Close the file
+        f.close()
+
+    def write_field_slices( self, field_grp, data, path, iz_min, iz_max ):
+        """
+        Writes the slices of a given field into the openPMD file
+        """
+        dset = field_grp[ path ]
+        dset[:, :, iz_min:iz_max ] = data
+
+class LabSnapshot:
+    """
+    Class that stores data relative to one given snapshot
+    in the lab frame (i.e. one given *time* in the lab frame)
+    """
+    def __init__(self, t_lab, zmin_lab, zmax_lab,
+                    write_dir, i, fld, Nr_output):
+        """
+        Initialize a LabSnapshot
+
+        Parameters
+        ----------
+        t_lab: float (seconds)
+            Time of this snapshot *in the lab frame*
+
+        zmin_lab, zmax_lab: floats
+            Longitudinal limits of this snapshot
+
+        write_dir: string
+            Absolute path to the directory where the data for
+            this snapshot is to be written
+
+        i: int
+           Number of the file where this snapshot is to be written
+
+        fld: a Fields object
+           This is passed only in order to determine how to initialize
+           the slice_array buffer (either on the CPU or GPU)
+
+        Nr_output: int
+            Number of cells in the r direction, in the final output
+            (This typically excludes the radial damping cells)
+        """
+        # Deduce the name of the filename where this snapshot writes
+        self.filename = os.path.join( write_dir, 'hdf5/data%08d.h5' %i)
+        self.iteration = i
+
+        # Time and boundaries in the lab frame (constants quantities)
+        self.zmin_lab = zmin_lab
+        self.zmax_lab = zmax_lab
+        self.t_lab = t_lab
+
+        # Positions where the fields are to be registered
+        # (Change at every iteration)
+        self.current_z_lab = 0
+        self.current_z_boost = 0
+
+        # Buffered field slice and corresponding array index in z
+        self.buffered_slices = []
+        self.buffer_z_indices = []
+
+        # Allocate a buffer for only one slice (avoids having to
+        # reallocate arrays when running on the GPU)
+        data_shape = (10, 2*fld.Nm-1, Nr_output)
+        if fld.use_cuda is False:
+            self.slice_array = np.empty( data_shape )
+        else:
+            self.slice_array = cupy.empty( data_shape )
+
+    def update_current_output_positions( self, t_boost, inv_gamma, inv_beta ):
+        """
+        Update the positions of output for this snapshot, so that
+        if corresponds to the time t_boost in the boosted frame
+
+        Parameters
+        ----------
+        t_boost: float (seconds)
+            Time of the current iteration, in the boosted frame
+
+        inv_gamma, inv_beta: floats
+            Inverse of the Lorentz factor of the boost, and inverse
+            of the corresponding beta.
+        """
+        t_lab = self.t_lab
+
+        # This implements the Lorentz transformation formulas,
+        # for a snapshot having a fixed t_lab
+        self.current_z_boost = ( t_lab*inv_gamma - t_boost )*c*inv_beta
+        self.current_z_lab = ( t_lab - t_boost*inv_gamma )*c*inv_beta
+
+    def register_slice( self, inv_dz_lab ):
+        """
+        Store the slice of fields represented by self.slice_array
+        and also store the z index at which this slice should be
+        written in the final lab frame array
+
+        Parameters
+        ----------
+        inv_dz_lab: float
+            Inverse of the grid spacing in z, *in the lab frame*
+        """
+        # Find the index of the slice in the lab frame
+        if self.buffer_z_indices == []:
+            # No previous index: caculate it from the absolute z_lab
+            iz_lab = int( (self.current_z_lab - self.zmin_lab)*inv_dz_lab )
+        else:
+            # By construction, this index shoud be the previous index - 1
+            # Handling integers avoids unstable roundoff errors, when
+            # self.current_z_lab is very close to zmin_lab + iz_lab*dz_lab
+            iz_lab = self.buffer_z_indices[-1] - 1
+
+        # Store the array and the index
+        self.buffer_z_indices.append( iz_lab )
+        # Make a copy of the array if it is directly on the CPU
+        if type(self.slice_array) is np.ndarray:
+            self.buffered_slices.append( self.slice_array.copy() )
+        # or copy from the GPU
+        else:
+            self.buffered_slices.append( self.slice_array.get() )
+
+    def compact_slices(self):
+        """
+        Compact the successive slices that have been buffered
+        over time into a single array, and return the indices
+        at which this array should be written.
+
+        Returns
+        -------
+        field_array: an array of reals of shape (10, 2*Nm-1, Nr_output, nslices)
+        In the above nslices is the number of buffered slices
+
+        iz_min, iz_max: integers
+        The indices between which the slices should be written
+        (iz_min is inclusive, iz_max is exclusive)
+
+        Returns None if the slices are empty
+        """
+        # Return None if the slices are empty
+        if len(self.buffer_z_indices) == 0:
+            return( None, None, None )
+
+        # Check that the indices of the slices are contiguous
+        # (This should be a consequence of the transformation implemented
+        # in update_current_output_positions, and of the calculation
+        # of inv_dz_lab.)
+        iz_old = self.buffer_z_indices[0]
+        for iz in self.buffer_z_indices[1:]:
+            if iz != iz_old - 1:
+                raise UserWarning('In the boosted frame diagnostic, '
+                        'the buffered slices are not contiguous in z.\n'
+                        'The boosted frame diagnostics may be inaccurate.')
+                break
+            iz_old = iz
+
+        # Pack the different slices together
+        # Reverse the order of the slices when stacking the array,
+        # since the slices where registered for right to left
+        field_array = np.stack( self.buffered_slices[::-1], axis=-1 )
+
+        # Get the first and last index in z
+        # (Following Python conventions, iz_min is inclusive,
+        # iz_max is exclusive)
+        iz_min = self.buffer_z_indices[-1]
+        iz_max = self.buffer_z_indices[0] + 1
+
+        return( field_array, iz_min, iz_max )
+
+class SliceHandler:
+    """
+    Class that extracts, Lorentz-transforms and writes slices of the fields
+    """
+    def __init__( self, gamma_boost, beta_boost, Nr_output ):
+        """
+        Initialize the SliceHandler object
+
+        Parameters
+        ----------
+        gamma_boost, beta_boost: floats
+            The Lorentz factor of the boost and the corresponding beta
+
+        Nr_output: int
+            Number of cells in the r direction, in the final output
+            (This typically excludes the radial damping cells)
+        """
+        # Store the arguments
+        self.gamma_boost = gamma_boost
+        self.beta_boost = beta_boost
+        self.Nr_output = Nr_output
+
+        # Create a dictionary that contains the correspondance
+        # between the field names and array index
+        self.field_to_index = {'Er':0, 'Et':1, 'Ez':2, 'Br':3,
+                'Bt':4, 'Bz':5, 'Jr':6, 'Jt':7, 'Jz':8, 'rho':9}
+
+    def extract_slice( self, fld, comm, z_boost, zmin_boost, slice_array ):
+        """
+        Fills `slice_array` with a slice of the fields at z_boost
+        (the fields returned are still in the boosted frame ;
+        for performance, the Lorentz transform of the fields values
+        is performed only when flushing to disk)
+
+        Parameters
+        ----------
+        fld: a Fields object
+            The object from which to extract the fields
+
+        comm: a BoundaryCommunicator object
+            Contains information about the gard cells in particular
+
+        z_boost: float (meters)
+            Position of the slice in the boosted frame
+
+        zmin_boost: float (meters)
+            Position of the left end of physical part of the local subdomain
+            (i.e. excludes guard cells)
+
+        slice_array: either a numpy array or a cuda device array
+            An array of reals that packs together the slices of the
+            different fields (always on array on the CPU).
+            The first index of this array corresponds to the field type
+            (10 different field types), and the correspondance
+            between the field type and integer index is given field_to_index
+            The shape of this arrays is (10, 2*Nm-1, Nr_output)
+        """
+        # Find the index of the slice in the boosted frame
+        # and the corresponding interpolation shape factor
+        dz = fld.interp[0].dz
+        # Find the interpolation data in the z direction
+        z_staggered_gridunits = ( z_boost - zmin_boost - 0.5*dz )/dz
+        iz = int( z_staggered_gridunits )
+        Sz = iz + 1 - z_staggered_gridunits
+        # Add the guard cells to the index iz
+        if comm is not None:
+            iz += comm.n_guard
+            if comm.left_proc is None:
+                iz += comm.nz_damp+comm.n_inject
+
+        # Extract the slice directly on the CPU
+        # Fill the pre-allocated CPU array slice_array
+        if fld.use_cuda is False :
+            # Extract a slice of the fields *in the boosted frame*
+            # at z_boost, using interpolation, and store them in slice_array
+            self.extract_slice_cpu( fld, iz, Sz, slice_array )
+
+        # Extract the slice on the GPU
+        # Fill the pre-allocated GPU array slice_array
+        else:
+            # Prepare kernel call
+            dim_grid_1d, dim_block_1d = cuda_tpb_bpg_1d( self.Nr_output )
+
+            # Extract the slices
+            interp = fld.interp
+            for m in range(fld.Nm):
+                extract_slice_cuda[ dim_grid_1d, dim_block_1d ](
+                    self.Nr_output, iz, Sz, slice_array,
+                    interp[m].Er, interp[m].Et, interp[m].Ez,
+                    interp[m].Br, interp[m].Bt, interp[m].Bz,
+                    interp[m].Jr, interp[m].Jt, interp[m].Jz, interp[m].rho, m)
+
+    def extract_slice_cpu( self, fld, iz, Sz, slice_array ):
+        """
+        Extract a slice of the fields at iz and iz+1, and interpolated
+        between those two points using Sz and (1-Sz)
+
+        Parameters
+        ----------
+        fld: a Fields object
+
+        iz: int
+            Index at which to extract the fields
+
+        Sz: float
+            Interpolation shape factor used at iz
+
+        slice_array: np.ndarray
+            Array of shape (10, 2*Nm-1, Nr_output )
+        """
+        # Shortcut for the correspondance between field and integer index
+        f2i = self.field_to_index
+
+        # Loop through the fields, and extract the proper slice for each field
+        for quantity in self.field_to_index.keys():
+            # Here typical values for `quantity` are e.g. 'Er', 'Bz', 'rho'
+
+            # Interpolate the centered field in z
+            slice_array[ f2i[quantity], :, : ] = Sz*self.get_dataset(
+                                            fld, quantity, iz_slice=iz )
+            slice_array[ f2i[quantity], :, : ] += (1.-Sz) * self.get_dataset(
+                                            fld, quantity, iz_slice=iz+1 )
+
+    def get_dataset( self, fld, quantity, iz_slice ):
+        """
+        Extract a given quantity, at a given slice index, from the fields
+
+        Parameters
+        ----------
+        fld: a Fields object
+
+        quantity: string
+            Indicates the quantity to be extracted (e.g. 'Er', 'Bz', 'rho')
+
+        iz_slice: int
+            Indicates the position of the slice in the field array
+
+        Returns
+        -------
+        An array of reals, whose format is close to the final openPMD output.
+        In particular, the array of fields is of shape ( 2*Nm-1, Nr)
+        (real and imaginary part are separated for each mode)
+        """
+        # Shortcut
+        Nr = self.Nr_output
+
+        # Allocate the array to be returned
+        data_shape = (2*fld.Nm-1, Nr)
+        output_array = np.empty( data_shape )
+
+        # Get the mode 0 : only the real part is non-zero
+        output_array[0,:] = getattr(fld.interp[0], quantity)[iz_slice,:Nr].real
+        # Get the higher modes
+        # There is a factor 2 here so as to comply with the convention in
+        # Lifschitz et al., which is also the convention adopted in FBPIC
+        for m in range(1,fld.Nm):
+            higher_mode_slice = 2*getattr(fld.interp[m], quantity)[iz_slice,:Nr]
+            output_array[2*m-1, :] = higher_mode_slice.real
+            output_array[2*m, :] = higher_mode_slice.imag
+
+        return( output_array )
+
+    def transform_fields_to_lab_frame( self, fields ):
+        """
+        Modifies the array `fields` in place, to transform the field values
+        from the boosted frame to the lab frame.
+
+        The transformation is a transformation with -beta_boost, thus
+        the corresponding formulas are:
+        - for the transverse part of E and B:
+        $\vec{E}_{lab} = \gamma(\vec{E} - c\vec{\beta} \times\vec{B})$
+        $\vec{B}_{lab} = \gamma(\vec{B} + \vec{\beta}/c \times\vec{E})$
+        - for rho and Jz:
+        $\rho_{lab} = \gamma(\rho + \beta J_{z}/c)$
+        $J_{z,lab} = \gamma(J_z + c\beta \rho)$
+
+        Parameter
+        ---------
+        fields: array of floats
+            An array that packs together the slices of the different fields.
+            The shape of this arrays is (10, 2*Nm-1, Nr_output, nslices)
+            where nslices is the number of slices that have been buffered
+        """
+        # Some shortcuts
+        gamma = self.gamma_boost
+        cbeta = c*self.beta_boost
+        beta_c = self.beta_boost/c
+        # Shortcut to give the correspondance between field name
+        # (e.g. 'Ex', 'rho') and integer index in the array
+        f2i = self.field_to_index
+
+        # Lorentz transformations
+        # For E and B
+        # (NB: Ez and Bz are unchanged by the Lorentz transform)
+        # Use temporary arrays when changing Er and Bt in place
+        er_lab = gamma*( fields[f2i['Er']] + cbeta * fields[f2i['Bt']] )
+        bt_lab = gamma*( fields[f2i['Bt']] + beta_c * fields[f2i['Er']] )
+        fields[ f2i['Er'], ... ] = er_lab
+        fields[ f2i['Bt'], ... ] = bt_lab
+        # Use temporary arrays when changing Et and Br in place
+        et_lab = gamma*( fields[f2i['Et']] - cbeta * fields[f2i['Br']] )
+        br_lab = gamma*( fields[f2i['Br']] - beta_c * fields[f2i['Et']] )
+        fields[ f2i['Et'], ... ] = et_lab
+        fields[ f2i['Br'], ... ] = br_lab
+        # For rho and J
+        # (NB: the transverse components of J are unchanged)
+        # Use temporary arrays when changing rho and Jz in place
+        rho_lab = gamma*( fields[f2i['rho']] + beta_c * fields[f2i['Jz']] )
+        Jz_lab =  gamma*( fields[f2i['Jz']] + cbeta * fields[f2i['rho']] )
+        fields[ f2i['rho'], ... ] = rho_lab
+        fields[ f2i['Jz'], ... ] = Jz_lab
+
+if cuda_installed:
+
+    @compile_cupy
+    def extract_slice_cuda( Nr, iz, Sz, slice_arr,
+        Er, Et, Ez, Br, Bt, Bz, Jr, Jt, Jz, rho, m ):
+        """
+        Extract a slice of the fields at iz and iz+1, and interpolated
+        between those two points using Sz and (1-Sz)
+
+        Parameters
+        ----------
+        Nr: int
+            Number of cells transversally
+
+        iz: int
+            Index at which to extract the fields
+
+        Sz: float
+            Interpolation shape factor used at iz
+
+        slice_arr: cupy.empty
+            Array of floats of shape (10, 2*Nm-1, Nr)
+
+        Er, Et, etc...: cupy.empty
+            Array of complexs of shape (Nz, Nr), for the azimuthal mode m
+
+        m: int
+            Index of the azimuthal mode involved
+        """
+        # One thread per radial position
+        ir = cuda.grid(1)
+        # Intermediate variables
+        izp = iz+1
+        Szp = 1. - Sz
+
+        if ir < Nr:
+            # Interpolate the field in the longitudinal direction
+            # and store it into pre-packed arrays
+
+            # For the higher modes:
+            # There is a factor 2 here so as to comply with the convention in
+            # Lifschitz et al., which is also the convention of FBPIC
+            # For performance, this is included in the shape factor.
+            if m > 0:
+                Sz = 2*Sz
+                Szp = 2*Szp
+                # Index at which the mode should be added
+                # in the array `slice_arr`
+                im = 2*m-1
+            else:
+                im = 0
+
+            # Real part
+            slice_arr[0,im,ir] = Sz*Er[iz,ir].real + Szp*Er[izp,ir].real
+            slice_arr[1,im,ir] = Sz*Et[iz,ir].real + Szp*Et[izp,ir].real
+            slice_arr[2,im,ir] = Sz*Ez[iz,ir].real + Szp*Ez[izp,ir].real
+            slice_arr[3,im,ir] = Sz*Br[iz,ir].real + Szp*Br[izp,ir].real
+            slice_arr[4,im,ir] = Sz*Bt[iz,ir].real + Szp*Bt[izp,ir].real
+            slice_arr[5,im,ir] = Sz*Bz[iz,ir].real + Szp*Bz[izp,ir].real
+            slice_arr[6,im,ir] = Sz*Jr[iz,ir].real + Szp*Jr[izp,ir].real
+            slice_arr[7,im,ir] = Sz*Jt[iz,ir].real + Szp*Jt[izp,ir].real
+            slice_arr[8,im,ir] = Sz*Jz[iz,ir].real + Szp*Jz[izp,ir].real
+            slice_arr[9,im,ir] = Sz*rho[iz,ir].real + Szp*rho[izp,ir].real
+
+            if m > 0:
+                # Imaginary part
+                slice_arr[0,im+1,ir] = Sz*Er[iz,ir].imag + Szp*Er[izp,ir].imag
+                slice_arr[1,im+1,ir] = Sz*Et[iz,ir].imag + Szp*Et[izp,ir].imag
+                slice_arr[2,im+1,ir] = Sz*Ez[iz,ir].imag + Szp*Ez[izp,ir].imag
+                slice_arr[3,im+1,ir] = Sz*Br[iz,ir].imag + Szp*Br[izp,ir].imag
+                slice_arr[4,im+1,ir] = Sz*Bt[iz,ir].imag + Szp*Bt[izp,ir].imag
+                slice_arr[5,im+1,ir] = Sz*Bz[iz,ir].imag + Szp*Bz[izp,ir].imag
+                slice_arr[6,im+1,ir] = Sz*Jr[iz,ir].imag + Szp*Jr[izp,ir].imag
+                slice_arr[7,im+1,ir] = Sz*Jt[iz,ir].imag + Szp*Jt[izp,ir].imag
+                slice_arr[8,im+1,ir] = Sz*Jz[iz,ir].imag + Szp*Jz[izp,ir].imag
+                slice_arr[9,im+1,ir] = Sz*rho[iz,ir].imag + Szp*rho[izp,ir].imag
+
+
+# Alias, for backward compatibility
+BoostedFieldDiagnostic = BackTransformedFieldDiagnostic

--- a/examples/multi_model_mt/custom_ptcl_diags.py
+++ b/examples/multi_model_mt/custom_ptcl_diags.py
@@ -1,0 +1,923 @@
+# Copyright 2016, FBPIC contributors
+# Authors: Remi Lehe, Manuel Kirchen
+# License: 3-Clause-BSD-LBNL
+"""
+This file defines the class BoostedParticleDiagnostic
+
+Major features:
+- The class reuses the existing methods of ParticleDiagnostic
+  as much as possible through class inheritance
+- The class implements memory buffering of the slices, so as
+  not to write to disk at every timestep
+"""
+import os
+import math
+import numpy as np
+from scipy.constants import c, e
+from fbpic.openpmd_diag.particle_diag import ParticleDiagnostic
+
+# Check if CUDA is available, then import CUDA functions
+from fbpic.utils.cuda import cuda_installed
+if cuda_installed:
+    from fbpic.openpmd_diag.cuda_methods import extract_slice_from_gpu
+
+class BackTransformedParticleDiagnostic(ParticleDiagnostic):
+    """
+    Class that writes the particles *in the lab frame*,
+    from a simulation in the boosted frame
+
+    Particles are extracted from the simulation in slices each time step
+    and buffered in memory before writing to disk. On the CPU, slices of
+    particles are directly selected from the particle arrays of the species.
+    On the GPU, first particles within an area of cells surrounding the
+    output planes are extracted from the GPU particle arrays and stored in
+    a smaller GPU array, which is then copied to the CPU for selection.
+    The mechanism of extracting the particles within the outputplane-area
+    on the GPU relies on particle arrays being sorted on the GPU. For the
+    back-transformation to the Lab frame, interpolation in space is applied,
+    but no interpolation for the particle velocities is applied.
+    """
+    def __init__(self, zmin_lab, zmax_lab, v_lab, t_start_lab, dt_snapshots_lab,
+                 Ntot_snapshots_lab, gamma_boost, period, fldobject,
+                 particle_data=["position", "momentum", "weighting"],
+                 select=None, write_dir=None, species={"electrons": None},
+                 comm = None):
+        """
+        Initialize diagnostics that retrieve the data in the lab frame,
+        as a series of snapshot (one file per snapshot),
+        within a virtual moving window defined by zmin_lab, zmax_lab, v_lab.
+
+        The parameters defined below are specific to the back-transformed
+        diagnostics. See the documentation of `ParticleDiagnostic` for
+        the other parameters.
+
+        .. warning::
+
+            The output of the gathered fields on the particles
+            (``particle_data=["E", "B"]``) and of the Lorentz factor
+            (``particle_data=["gamma"]``) is not currently supported
+            for ``BackTransformedParticleDiagnostic``.
+
+        Parameters
+        ----------
+        zmin_lab: float (in meters)
+            The position of the left edge of the virtual moving window,
+            *in the lab frame*, at t=0
+        zmax_lab: float (in meters)
+            The position of the right edge of the virtual moving window,
+            *in the lab frame*, at t=0
+
+        v_lab: float (m.s^-1)
+            Speed of the moving window *in the lab frame*
+
+        dt_snapshots_lab: float (seconds)
+            Time interval *in the lab frame* between two successive snapshots
+
+        Ntot_snapshots_lab: int
+            Total number of snapshots that this diagnostic will produce
+
+        period: int
+            Number of iterations for which the data is accumulated in memory,
+            before finally writing it to the disk.
+
+        fldobject : a Fields object,
+            The Fields object of the simulation, that is needed to
+            extract some information about the grid
+        """
+        # Do not leave write_dir as None, as this may conflict with
+        # the default directory ('./diags') in which diagnostics in the
+        # boosted frame are written
+        if write_dir is None:
+            write_dir = 'lab_diags'
+
+        # Initialize Particle diagnostic normal attributes
+        ParticleDiagnostic.__init__(self, period, species,
+            comm, particle_data, select, write_dir)
+
+        # Register the Field object
+        self.fld = fldobject
+
+        # Register the boost quantities
+        self.gamma_boost = gamma_boost
+        self.inv_gamma_boost = 1./gamma_boost
+        self.beta_boost = np.sqrt(1. - self.inv_gamma_boost**2)
+        self.inv_beta_boost = 1./self.beta_boost
+
+        # Create the list of LabSnapshot objects
+        self.snapshots = []
+        for i in range( Ntot_snapshots_lab ):
+            t_lab = t_start_lab + i*dt_snapshots_lab
+            snapshot = LabSnapshot( t_lab,
+                                    zmin_lab + v_lab*t_lab,
+                                    zmax_lab + v_lab*t_lab,
+                                    self.dt,
+                                    self.write_dir, i ,self.species_dict )
+            self.snapshots.append(snapshot)
+            # Initialize a corresponding empty file to store particles
+            self.create_file_empty_slice(
+                    snapshot.filename, i, snapshot.t_lab, self.dt)
+
+        # Create the ParticleCatcher object
+        # (This object will extract the particles (slices) that crossed the
+        # output plane at each iteration.)
+        self.particle_catcher = ParticleCatcher(
+            self.gamma_boost, self.beta_boost, self.fld )
+
+    def write( self, iteration ):
+        """
+        Redefines the method write of the parent class ParticleDiagnostic
+
+        Parameters
+        ----------
+        iteration : int
+            Current iteration of the boosted frame simulation
+        """
+        # At each timestep, store a slice of the particles in memory buffers
+        self.store_snapshot_slices(iteration)
+
+        # Every self.period, write the buffered slices to disk
+        if iteration % self.period == 0:
+            self.flush_to_disk()
+
+    def store_snapshot_slices( self, iteration ):
+        """
+        Store slices of the particles in the memory buffers of the
+        corresponding lab snapshots
+
+        Parameters
+        ----------
+        iteration : int
+            Current iteration of the boosted frame simulation
+        """
+        # Find the limits of the local subdomain at this iteration
+        zmin_boost = self.fld.interp[0].zmin
+        zmax_boost = self.fld.interp[0].zmax
+
+        # Extract the current time in the boosted frame
+        time = iteration * self.dt
+
+        # Loop through the labsnapshots
+        for snapshot in self.snapshots:
+
+            # Update the positions of the output slice of this snapshot
+            # in the lab and boosted frame (current_z_lab and current_z_boost)
+            snapshot.update_current_output_positions( time,
+                self.inv_gamma_boost, self.inv_beta_boost)
+
+            # For this snapshot:
+            # - check if the output position *in the boosted frame*
+            #   is in the current local domain
+            # - check if the output position *in the lab frame*
+            #   is within the lab-frame boundaries of the current snapshot
+            if ( (snapshot.current_z_boost >= zmin_boost) and \
+                 (snapshot.current_z_boost < zmax_boost) and \
+                 (snapshot.current_z_lab >= snapshot.zmin_lab) and \
+                 (snapshot.current_z_lab < snapshot.zmax_lab) ):
+
+                # Loop through the particle species and register the
+                # data dictionaries in the snapshot objects (buffering)
+                for species_name in self.species_names_list:
+                    species = self.species_dict[species_name]
+                    # Extract the slice of particles
+                    slice_data_dict = self.particle_catcher.extract_slice(
+                        species, snapshot.current_z_boost,
+                        snapshot.prev_z_boost, time, self.select)
+                    # Register new slice in the LabSnapshot
+                    snapshot.register_slice( slice_data_dict, species_name )
+
+    def flush_to_disk(self):
+        """
+        Writes the buffered slices of particles to the disk. Erase the
+        buffered slices of the LabSnapshot objects
+        """
+        # Loop through the labsnapshots and flush the data
+        for snapshot in self.snapshots:
+
+            # Compact the successive slices that have been buffered
+            # over time into a single array
+            for species_name in self.species_names_list:
+
+                # Get list of quantities to be written to file
+                quantities_in_file = self.array_quantities_dict[species_name]
+
+                # Compact the slices in a single array (on each proc)
+                local_particle_dict = snapshot.compact_slices(species_name,
+                                    quantities_in_file )
+
+                # Gather the slices on the first proc
+                if self.comm is not None and self.comm.size > 1:
+                    particle_dict = self.gather_particle_arrays(
+                        local_particle_dict, quantities_in_file )
+                else:
+                    particle_dict = local_particle_dict
+
+                # The first proc writes this array to disk
+                # (if this snapshot has new slices)
+                if self.rank==0:
+                    self.write_slices( particle_dict, species_name, snapshot )
+
+                # Erase the previous slices
+                snapshot.buffered_slices[species_name] = []
+
+    def gather_particle_arrays( self, local_dict, quantities_in_file ):
+        """
+        Gather the compacted arrays of particle slices, on the proc `root`
+
+        Parameters:
+        -----------
+        local_dict: A dictionary of 1d arrays of shape (n_particles_local,)
+            A dictionary that contains the quantities on one MPI rank.
+        quantities_in_file: list of strings
+            The quantities that will be written into the openPMD
+            file, for this species.
+
+        Returns:
+        --------
+        gathered_dict: A dictionary of 1d arrays of shape (n_particles_total,)
+        (None is returned on all other processors than root.)
+        """
+        # Send the local number of particles to all procs
+        n_particles_local = len( local_dict[ quantities_in_file[0] ] )
+        n_particles_list = self.comm.mpi_comm.allgather( n_particles_local )
+
+        # Prepare the send and receive buffers
+        gathered_dict = {}
+        n_particles_tot = sum( n_particles_list )
+        # Loop through the quantities and perform the MPI gather
+        for quantity in quantities_in_file:
+            gathered_dict[quantity] = self.comm.gather_ptcl_array(
+                local_dict[quantity], n_particles_list, n_particles_tot )
+
+        # Return the gathered dictionary
+        return( gathered_dict )
+
+    def write_slices( self, particle_dict, species_name, snapshot ):
+        """
+        For one given snapshot, write the slices of the
+        different species to an openPMD file
+
+        Parameters
+        ----------
+        particle_dict: A dictionary of 1d arrays of shape (n_particles_local,)
+            A dictionary that contains the different particle quantities,
+            whose keys are self.arrays_quantities[species_name]
+
+        species_name: String
+            A String that acts as the key for the buffered_slices dictionary
+
+        snapshot: a LabSnaphot object
+        """
+        # Open the file without parallel I/O in this implementation
+        f = self.open_file(snapshot.filename)
+        particle_path = "/data/%d/particles/%s" %(snapshot.iteration,
+            species_name)
+        species_grp = f[particle_path]
+
+        # Loop over the different quantities that should be written
+        for quantity in self.array_quantities_dict[species_name]:
+
+            if quantity in ["x","y","z"]:
+                path = "position/%s" %(quantity)
+                data = particle_dict[ quantity ]
+                self.write_particle_slices(species_grp, path, data, quantity)
+
+            elif quantity in ["ux","uy","uz"]:
+                path = "momentum/%s" %(quantity[-1])
+                data = particle_dict[ quantity ]
+                self.write_particle_slices( species_grp, path, data, quantity)
+
+            elif quantity in ["w", "charge", "id"]:
+                if quantity == "w":
+                    path = "weighting"
+                else:
+                    path = quantity
+                data = particle_dict[ quantity ]
+                self.write_particle_slices(species_grp, path, data, quantity)
+
+        # Close the file
+        f.close()
+
+    def write_particle_slices( self, species_grp, path, data, quantity ):
+        """
+        Writes each quantity of the buffered dataset to the disk, the
+        final step of the writing
+        """
+        dset = species_grp[path]
+        index = dset.shape[0]
+
+        # Resize the h5py dataset
+        dset.resize(index+len(data), axis=0)
+
+        # Write the data to the dataset at correct indices
+        dset[index:] = data
+
+    def create_file_empty_slice( self, fullpath, iteration, time, dt ):
+        """
+        Create an openPMD file with empty meshes and setup all its attributes
+
+        Parameters
+        ----------
+        fullpath: string
+            The absolute path to the file to be created
+
+        iteration: int
+            The iteration number of this diagnostic
+
+        time: float (seconds)
+            The physical time at this ibteration
+
+        dt: float (seconds)
+            The timestep of the simulation
+        """
+        # Create the file
+        f = self.open_file( fullpath )
+
+        # Setup the different layers of the openPMD file
+        # (f is None if this processor does not participate is writing data)
+        if f is not None:
+
+            # Setup the attributes of the top level of the file
+            self.setup_openpmd_file( f, iteration, time, dt )
+            # Setup the meshes group (contains all the particles)
+            particle_path = "/data/%d/particles/" %iteration
+
+            for species_name in self.species_names_list:
+                species = self.species_dict[species_name]
+                species_path = particle_path+"%s/" %(species_name)
+                # Create and setup the h5py.Group species_grp
+                species_grp = f.require_group( species_path )
+                self.setup_openpmd_species_group( species_grp, species,
+                            self.constant_quantities_dict[species_name])
+
+                # Loop over the different quantities that should be written
+                # and setup the corresponding datasets
+                for quantity in self.array_quantities_dict[species_name]:
+
+                    if quantity in ["x", "y", "z"]:
+                        quantity_path = "position/%s" %(quantity)
+                        dset = species_grp.require_dataset(
+                                quantity_path, (0,),
+                                maxshape=(None,), dtype='f8')
+                        self.setup_openpmd_species_component( dset, quantity )
+
+                    elif quantity in ["ux", "uy", "uz"]:
+                        quantity_path = "momentum/%s" %(quantity[-1])
+                        dset = species_grp.require_dataset(
+                                quantity_path, (0,),
+                                maxshape=(None,), dtype='f8')
+                        self.setup_openpmd_species_component( dset, quantity )
+
+                    elif quantity in ["w", "id", "charge"]:
+                        if quantity == "w":
+                            particle_var = "weighting"
+                        else:
+                            particle_var = quantity
+                        if quantity == "id":
+                            dtype = 'uint64'
+                        else:
+                            dtype = 'f8'
+                        dset = species_grp.require_dataset(
+                            particle_var, (0,), maxshape=(None,), dtype=dtype )
+                        self.setup_openpmd_species_component( dset, quantity )
+                        self.setup_openpmd_species_record(
+                            species_grp[particle_var], particle_var )
+
+                    else :
+                        raise ValueError(
+                            "Invalid quantity for particle output: %s"
+                            %(quantity) )
+
+                # Setup the hdf5 groups for "position" and "momentum"
+                if self.rank == 0:
+                    if "x" in self.array_quantities_dict[species_name]:
+                        self.setup_openpmd_species_record(
+                            species_grp["position"], "position" )
+                    if "ux" in self.array_quantities_dict[species_name]:
+                        self.setup_openpmd_species_record(
+                            species_grp["momentum"], "momentum" )
+
+            # Close the file
+            f.close()
+
+class LabSnapshot:
+    """
+    Class that stores data relative to one given snapshot
+    in the lab frame (i.e. one given *time* in the lab frame)
+    """
+    def __init__( self, t_lab, zmin_lab, zmax_lab, dt,
+                  write_dir, i, species_dict ):
+        """
+        Initialize a LabSnapshot
+
+        Parameters
+        ----------
+        t_lab: float (seconds)
+            Time of this snapshot *in the lab frame*
+
+        zmin_lab, zmax_lab: floats (meters)
+            Longitudinal limits of this snapshot
+
+        write_dir: string
+            Absolute path to the directory where the data for
+            this snapshot is to be written
+
+        dt : float (s)
+            The timestep of the simulation in the boosted frame
+
+        i: int
+            Number of the file where this snapshot is to be written
+
+        species_dict: dict
+            Contains all the species name of the species object
+            (inherited from Warp)
+        """
+        # Deduce the name of the filename where this snapshot writes
+        self.filename = os.path.join( write_dir, 'hdf5/data%08d.h5' %i)
+        self.iteration = i
+        self.dt = dt
+
+        # Time and boundaries in the lab frame (constant quantities)
+        self.zmin_lab = zmin_lab
+        self.zmax_lab = zmax_lab
+        self.t_lab = t_lab
+
+        # Positions where the fields are to be registered
+        # (Change at every iteration)
+        self.current_z_lab = 0
+        self.current_z_boost = 0
+
+        # Initialize empty dictionary to buffer the slices for each species
+        self.buffered_slices = {}
+        for species in species_dict:
+            self.buffered_slices[species] = []
+
+    def update_current_output_positions( self, t_boost, inv_gamma, inv_beta ):
+        """
+        Update the current and previous positions of output for this snapshot,
+        so that it corresponds to the time t_boost in the boosted frame
+
+        Parameters
+        ----------
+        t_boost: float (seconds)
+            Time of the current iteration, in the boosted frame
+
+        inv_gamma, inv_beta: floats
+            Inverse of the Lorentz factor of the boost, and inverse
+            of the corresponding beta
+        """
+        # Some shorcuts for further calculation's purposes
+        t_lab = self.t_lab
+        t_boost_prev = t_boost - self.dt
+
+        # This implements the Lorentz transformation formulas,
+        # for a snapshot having a fixed t_lab
+        self.current_z_boost = (t_lab*inv_gamma - t_boost)*c*inv_beta
+        self.prev_z_boost = (t_lab*inv_gamma - t_boost_prev)*c*inv_beta
+        self.current_z_lab = (t_lab - t_boost*inv_gamma)*c*inv_beta
+        self.prev_z_lab = (t_lab - t_boost_prev*inv_gamma)*c*inv_beta
+
+    def register_slice( self, slice_data_dict, species ):
+        """
+        Store the slice of particles represented by slice_data_dict
+
+        Parameters
+        ----------
+        slice_data_dict : dictionary of 1D float and integer arrays
+            A dictionary that contains the particle data of
+            the simulation, including optional integer arrays (e.g. "id"),
+            as given by the ParticleCatcher object
+
+        species: String, key of the species_dict
+            Act as the key for the buffered_slices dictionary
+        """
+        # Store the values
+        self.buffered_slices[species].append(slice_data_dict)
+
+    def compact_slices( self, species, quantities_in_file ):
+        """
+        Compact the successive slices that have been buffered
+        over time into a single array.
+
+        Parameters
+        ----------
+        species: String, key of the species_dict
+            Act as the key for the buffered_slices dictionary
+
+        quantities_in_file: list of strings
+            The quantities that will be written into the openPMD
+            file, for this species.
+
+        Returns
+        -------
+        particle_data_dict: dictionary of 1D float and integer arrays
+            A dictionary that contains only the particle quantities
+            that will be finally written to file, with compacted arrays.
+        """
+        # Prepare dictionary
+        particle_data_dict = {}
+
+        # Loop through the particle quantities that will be written to file,
+        # and compact the buffered arrays into a single array
+        if self.buffered_slices[species] != []:
+            for quantity in quantities_in_file:
+                buffered_arrays = [ slice_dict[quantity] \
+                            for slice_dict in self.buffered_slices[species] ]
+                particle_data_dict[quantity] = np.concatenate(buffered_arrays)
+        else:
+            for quantity in quantities_in_file:
+                if quantity == 'id':
+                    dtype = np.uint64
+                else:
+                    dtype = np.float64
+                particle_data_dict[quantity] = np.zeros( (0,), dtype=dtype )
+
+        return(particle_data_dict)
+
+class ParticleCatcher:
+    """
+    Class that extracts, Lorentz-transforms and gathers particles
+    """
+    def __init__( self, gamma_boost, beta_boost, fldobject ):
+        """
+        Initialize the ParticleCatcher object
+
+        Parameters
+        ----------
+        gamma_boost, beta_boost: float
+            The Lorentz factor of the boost and the corresponding beta
+
+        fldobject : a Fields object,
+            The Fields object of the simulation, that is needed to
+            extract some information about the grid
+        """
+        # Some attributes necessary for particle selections
+        self.gamma_boost = gamma_boost
+        self.beta_boost = beta_boost
+
+        # Register the fields object
+        self.fld = fldobject
+        self.dt = self.fld.dt
+
+    def extract_slice( self, species, current_z_boost, previous_z_boost,
+                       t, select=None ):
+        """
+        Extract a slice of the particles at z_boost and if select is present,
+        extract only the particles that satisfy the given criteria
+
+        Parameters
+        ----------
+        species : A ParticleObject
+            Contains the particle attributes to output
+
+        current_z_boost, previous_z_boost : float (m)
+            Current and previous position of the output plane
+            in the boosted frame
+
+        t : float (s)
+            Current time of the simulation in the boosted frame
+
+        select : dict
+            A set of rules defined by the users in selecting the particles
+            z: {"uz" : [50, 100]} for particles which have normalized
+            momenta between 50 and 100
+
+        Returns
+        -------
+        slice_data_dict : dictionary of 1D float and integer arrays
+            A dictionary that contains the particle data of
+            the simulation (with normalized weigths), including optional
+            integer arrays (e.g. "id", "charge")
+        """
+        # Get a dictionary containing the particle data
+        # When running on the GPU, this only copies to CPU the particles
+        # within a small area around the output plane.
+        # (Return the result in the form of a dictionary of 1darrays)
+        particle_data_dict = self.get_particle_data(
+                species, current_z_boost, previous_z_boost, t )
+
+        # Get the selection of particles (slice) that crossed the
+        # output plane during the last iteration
+        # (Return the result in the form of a dictionary of smaller 1darrays)
+        slice_data_dict = self.get_particle_slice(
+                particle_data_dict, current_z_boost, previous_z_boost )
+
+        # Backpropagate particles to correct output position and
+        # transform particle attributes to the lab frame
+        # (Modifies the arrays of `slice_data_dict` in place.)
+        slice_data_dict = self.interpolate_particles_to_lab_frame(
+            slice_data_dict, current_z_boost, t )
+
+        # Choose the particles based on the select criteria defined by the
+        # users. Notice: this implementation still comes with a cost,
+        # one way to optimize it would be to do the selection before Lorentz
+        # transformation back to the lab frame
+        if (select is not None):
+            # Find the particles that should be selected and resize
+            # the arrays in `slice_data_dict` accordingly
+            slice_data_dict = self.apply_selection(select, slice_data_dict)
+
+        # Convert data to the OpenPMD standard
+        slice_data_dict = self.apply_opmd_standard( slice_data_dict, species )
+
+        return slice_data_dict
+
+    def get_particle_data( self, species, current_z_boost,
+                           previous_z_boost, t ):
+        """
+        Extract the particle data from the species object.
+        In case CUDA is used, only a selection of particles
+        (i.e. particles that are within cells corresponding
+        to the immediate neighborhood of the output plane)
+        is received from the GPU (increases performance).
+
+        Parameters
+        ----------
+        species : A ParticleObject
+            Contains the particle attributes to output
+        current_z_boost, previous_z_boost : float (m)
+            Current and previous position of the output plane
+            in the boosted frame
+        t : float (s)
+            Current time of the simulation in the boosted frame
+
+        Returns
+        -------
+        particle_data : A dictionary of 1D float and integer arrays
+            A dictionary that contains the particle data of
+            the simulation (with normalized weigths), including optional
+            integer arrays (e.g. "id", "charge")
+        """
+        # CPU
+        if species.use_cuda is False:
+            # Create a dictionary containing the particle attributes
+            particle_data = {
+                'x': species.x, 'y': species.y, 'z': species.z,
+                'ux': species.ux, 'uy' : species.uy, 'uz': species.uz,
+                'w': species.w, 'inv_gamma': species.inv_gamma }
+            # Optional integer quantities
+            if species.ionizer is not None:
+                particle_data['charge'] = species.ionizer.ionization_level
+            if species.tracker is not None:
+                particle_data['id'] = species.tracker.id
+        # GPU
+        else:
+            # Check if particles are sorted, otherwise sort them
+            if species.sorted == False:
+                species.sort_particles(fld=self.fld)
+                # The particles are now sorted and rearranged
+                species.sorted = True
+            # Precalculating quantities and shortcuts
+            dt = self.fld.dt
+            dz = self.fld.interp[0].dz
+            zmin = self.fld.interp[0].zmin
+            pref_sum = species.prefix_sum
+            pref_sum_shift = species.prefix_sum_shift
+            Nz, Nr = species.grid_shape
+            # Calculate cell area to get particles from
+            # - Get z indices of the slices in which to get the particles
+            # (mirrors the index calculation in `get_cell_idx_per_particle`)
+            iz_curr = int(math.ceil((current_z_boost-zmin-0.5*dz)/dz))
+            iz_prev = int(math.ceil((previous_z_boost-zmin-0.5*dz + dt*c)/dz)) + 1
+            # - Get the prefix sum values that correspond to these indices
+            #   (Take into account potential shift due to the moving window)
+            z_cell_curr = iz_curr + pref_sum_shift
+            if z_cell_curr <= 0:
+                pref_sum_curr = 0
+            elif z_cell_curr > Nz:
+                pref_sum_curr = species.Ntot
+            else:
+                pref_sum_curr = int(pref_sum[ z_cell_curr*(Nr+1) - 1 ])
+            z_cell_prev = iz_prev + pref_sum_shift
+            if z_cell_prev <= 0:
+                pref_sum_prev = 0
+            elif z_cell_prev > Nz:
+                pref_sum_prev = species.Ntot
+            else:
+                pref_sum_prev = int(pref_sum[ z_cell_prev*(Nr+1) - 1 ])
+            # Calculate number of particles in this area (N_area)
+            N_area = pref_sum_prev - pref_sum_curr
+            # Check if there are particles to extract
+            if N_area > 0:
+                # Only copy a particle slice of size N_area from the GPU
+                particle_data = extract_slice_from_gpu(
+                                    pref_sum_curr, N_area, species )
+            else:
+                # Empty particle data
+                particle_data = {}
+                for var in ['x', 'y', 'z', 'ux', 'uy', 'uz', 'w', 'inv_gamma']:
+                    particle_data[var] = np.empty( (0,), dtype=np.float64 )
+                # Empty optional integer quantities
+                if species.ionizer is not None:
+                    particle_data['charge'] = np.empty( (0,), dtype=np.uint64 )
+                if species.tracker is not None:
+                    particle_data['id'] = np.empty( (0,), dtype=np.uint64 )
+
+        return( particle_data )
+
+    def get_particle_slice( self, particle_data, current_z_boost,
+                             previous_z_boost ):
+        """
+        Get the selection of particles that crossed the output
+        plane during the last iteration.
+
+        Parameters
+        ----------
+        particle_data : dictionary of 1D float and integer arrays
+            A dictionary that contains the particle data of
+            the simulation (with normalized weigths), including optional
+            integer arrays (e.g. "id", "charge")
+
+        current_z_boost, previous_z_boost : float (m)
+            Current and previous position of the output plane
+            in the boosted frame
+
+        Returns
+        -------
+        slice_data : dictionary of 1D float and integer arrays
+            Contains the same keys as particle_data, but with smaller
+            arrays which contain only the particles of the slice.
+        """
+        # Shortcut
+        pd = particle_data
+
+        # Calculate current and previous position in z
+        current_z = pd['z']
+        previous_z = pd['z']-pd['uz']*pd['inv_gamma']*c*self.dt
+
+        # A particle array for mapping purposes
+        particle_indices = np.arange(len(current_z))
+
+        # For this snapshot:
+        # - check if the output position *in the boosted frame*
+        #   crosses the zboost in a forward motion
+        # - check if the output position *in the boosted frame*
+        #   crosses the zboost_prev in a backward motion
+        selected_indices = np.compress((
+            ((current_z >= current_z_boost)&(previous_z <= previous_z_boost))|
+            ((current_z <= current_z_boost)&(previous_z >= previous_z_boost))),
+            particle_indices)
+
+        # Create dictionary which contains only the selected particles
+        slice_data = {}
+        for quantity in pd.keys():
+            slice_data[quantity] = \
+                np.take( particle_data[quantity], selected_indices)
+
+        return( slice_data )
+
+    def interpolate_particles_to_lab_frame( self, slice_data_dict,
+                                                    current_z_boost, t ):
+        """
+        Transform the particle quantities from the boosted frame to the
+        lab frame. These are classical Lorentz transformation equations.
+
+        `slice_data_dict` is modified in place.
+
+        Parameters
+        ----------
+        slice_data_dict : dictionary of 1D float and integer arrays
+            A dictionary that contains the particle data of
+            the simulation (with normalized weigths), including optional
+            integer arrays (e.g. "id", "charge")
+
+        current_z_boost : float (m)
+            Current position of the output plane in the boosted frame
+
+        t : float (s)
+            Current time of the simulation in the boosted frame
+
+        Return
+        ------
+        slice_data_dict : dictionary of 1D float and integer arrays
+            A dictionary that contains the particle data of
+            the simulation (with normalized weigths), including optional
+            integer arrays (e.g. "id", "charge")
+        """
+        # Shortcuts for particle attributes
+        x = slice_data_dict['x']
+        y = slice_data_dict['y']
+        z = slice_data_dict['z']
+        ux = slice_data_dict['ux']
+        uy = slice_data_dict['uy']
+        uz = slice_data_dict['uz']
+        inv_gamma = slice_data_dict['inv_gamma']
+
+        # Calculate time (t_cross) when particle and plane intersect
+        # Velocity of the particles
+        v_z = uz*inv_gamma*c
+        # Velocity of the plane
+        v_plane = -c/self.beta_boost
+        # Time in the boosted frame when particles cross the output plane
+        t_cross = t - (current_z_boost - z) / (v_plane - v_z)
+
+        # Push particles to position of plane intersection
+        x += c*(t_cross - t)*inv_gamma*ux
+        y += c*(t_cross - t)*inv_gamma*uy
+        z += c*(t_cross - t)*inv_gamma*uz
+
+        # Back-transformation of position with updated time (t_cross)
+        z_lab = self.gamma_boost*( z + self.beta_boost*c*t_cross )
+
+        # Back-transformation of momentum
+        gamma = 1./inv_gamma
+        uz_lab = self.gamma_boost*uz + gamma*(self.beta_boost*self.gamma_boost)
+
+        # Replace the arrays that have been modified, in `slice_data_dict`
+        slice_data_dict['x'] = x
+        slice_data_dict['y'] = y
+        slice_data_dict['z'] = z_lab
+        slice_data_dict['uz'] = uz_lab
+        # Remove `inv_gamma`, since it is not needed anymore, now at the
+        # Lorentz transform has been performed.
+        slice_data_dict.pop('inv_gamma')
+
+        return(slice_data_dict)
+
+    def apply_opmd_standard( self, slice_data_dict, species ):
+        """
+        Apply the OpenPMD standard to the particle quantities.
+        Momentum (u) is multiplied by m * c and weights are
+        divided by the particle charge q.
+        'Charge' (for ionizable ions) is multiplied by e, and
+        thus becomes a float array.
+
+        Parameters
+        ----------
+        slice_data_dict : dictionary of 1D float and integer arrays
+            A dictionary that contains the particle data of
+            the simulation (with normalized weigths), including optional
+            integer arrays (e.g. "id", "charge")
+
+        species : A ParticleObject
+            Contains the particle data and the meta-data
+            needed for the conversion to the OpenPMD format.
+
+        Returns
+        -------
+        slice_data_dict : dictionary of 1D float and integer arrays
+            A dictionary that contains the particle data of
+            the simulation (with normalized weigths), including optional
+            integer arrays (e.g. "id")
+        """
+        # Normalize momenta
+        # (only for species that have a mass)
+        for quantity in ['ux', 'uy', 'uz']:
+            if species.m > 0:
+                slice_data_dict[quantity] *= species.m * c
+        # Convert ionizable level (integer) to charge in Coulombs (float)
+        if 'charge' in slice_data_dict:
+            slice_data_dict['charge'] = slice_data_dict['charge']*e
+
+        return slice_data_dict
+
+    def apply_selection( self, select, slice_data_dict ) :
+        """
+        Apply the rules of self.select to determine which
+        particles should be written. Modify the arrays of
+        `slice_data_dict` so that only the selected particles remain.
+
+        Parameters
+        ----------
+        select : a dictionary that defines all selection rules based
+        on the quantities
+
+        slice_data_dict : dictionary of 1D float and integer arrays
+            A dictionary that contains the particle data of
+            the simulation (with normalized weigths), including optional
+            integer arrays (e.g. "id", "charge")
+
+        Returns
+        -------
+        slice_data_dict : dictionary of 1D float and integer arrays
+            A dictionary that contains the particle data of
+            the simulation (with normalized weigths), including optional
+            integer arrays (e.g. "id", "charge")
+        """
+        # Initialize an array filled with True
+        N_part_slice = len( slice_data_dict['w'] )
+        select_array = np.ones( N_part_slice, dtype='bool' )
+
+        # Apply the rules successively
+        # Go through the quantities on which a rule applies
+        for quantity in select.keys() :
+            # Lower bound
+            if select[quantity][0] is not None :
+                select_array = np.logical_and( select_array,
+                    slice_data_dict[quantity] > select[quantity][0] )
+            # Upper bound
+            if select[quantity][1] is not None :
+                select_array = np.logical_and( select_array,
+                    slice_data_dict[quantity] < select[quantity][1] )
+        # At this point, `select_array` contains True
+        # wherever a particle should be kept
+
+        # Loop through the keys of `select_array` and select only the
+        # particles that should be kept.
+        for quantity in slice_data_dict.keys():
+            slice_data_dict[quantity] = slice_data_dict[quantity][select_array]
+
+        return slice_data_dict
+
+
+# Alias, for backward compatibility
+BoostedParticleDiagnostic = BackTransformedParticleDiagnostic

--- a/examples/multi_model_mt/mt_parameters.py
+++ b/examples/multi_model_mt/mt_parameters.py
@@ -1,0 +1,14 @@
+""""
+Contains the parameters for multi-fidelity optimization.
+"""
+
+mt_parameters = {
+    'name_hifi': 'fbpic',
+    'name_lofi': 'wake-t',
+    'n_init_hifi': 4,
+    'n_init_lofi': 20,
+    'n_opt_hifi': 4,
+    'n_opt_lofi': 20,    
+    'extra_args_lofi': '-np 1 --bind-to none',
+    'extra_args_hifi': '-np 1 --bind-to none'
+}

--- a/examples/multi_model_mt/run_opt.py
+++ b/examples/multi_model_mt/run_opt.py
@@ -1,0 +1,34 @@
+from libensemble.tools import parse_args
+from libe_opt.ensemble_runner import run_ensemble
+
+from varying_parameters import varying_parameters
+from analysis_script import analyze_simulation, analyzed_quantities
+from mt_parameters import mt_parameters
+
+
+# Ensemble parameters.
+gen_type = 'bo'
+backend = 'ax'
+n_batches = 10
+sim_max = (
+    (mt_parameters['n_opt_lofi'] + mt_parameters['n_opt_hifi']) * n_batches
+    + mt_parameters['n_init_lofi'] + mt_parameters['n_init_hifi']
+)
+run_async = False
+nworkers, is_master, libE_specs, _ = parse_args()
+
+
+# Files to copy to each simulation folder.
+libE_specs['sim_dir_copy_files'] = [
+    'bunch_utils.py',
+    'custom_fld_diags.py',
+    'custom_ptcl_diags.py'
+]
+
+
+# Run optimization.
+run_ensemble(
+    nworkers, sim_max, is_master, gen_type, bo_backend=backend,
+    analyzed_params=analyzed_quantities, var_params=varying_parameters,
+    analysis_func=analyze_simulation, mt_params=mt_parameters,
+    libE_specs=libE_specs, run_async=run_async)

--- a/examples/multi_model_mt/template_simulation_wt_fb.py
+++ b/examples/multi_model_mt/template_simulation_wt_fb.py
@@ -1,0 +1,300 @@
+import numpy as np
+import scipy.constants as ct
+from wake_t import GaussianPulse, PlasmaStage, ParticleBunch
+import aptools.plasma_accel.general_equations as ge
+from bunch_utils import trapezoidal_bunch
+from fbpic.main import Simulation
+# from fbpic.openpmd_diag import (
+#     BackTransformedFieldDiagnostic, BackTransformedParticleDiagnostic)
+from custom_fld_diags import BackTransformedFieldDiagnostic
+from custom_ptcl_diags import BackTransformedParticleDiagnostic
+from fbpic.lpa_utils.boosted_frame import BoostConverter
+from fbpic.lpa_utils.bunch import add_particle_bunch_from_arrays
+from fbpic.lpa_utils.laser import add_laser
+
+
+# Parammeters exposed to optimizer.
+task = {{task}}
+beam_i_1 = {{beam_i_1}}
+beam_i_2 = {{beam_i_2}}
+beam_z_i_2 = {{beam_z_i_2}}
+beam_length = {{beam_length}}
+
+
+# General simulation parameters.
+n_p_plateau = 2e23
+l_plateau = 10e-2
+w0_laser = 40e-6
+z_beam = (50 + beam_z_i_2) * 1e-6
+l_beam = beam_length * 1e-6
+i1_beam = beam_i_1 * 1e3
+i2_beam = beam_i_2 * 1e3
+
+
+def run_simulation():
+    # Base laser parameters.
+    E_laser = 10  # J
+    tau_laser = 25e-15  # s (fwhm)
+    lambda0 = 0.8e-6  # m
+    a0 = determine_laser_a0(E_laser, tau_laser, w0_laser, lambda0)
+
+    # Base beam parameters.
+    E_beam = 200  # MeV
+    gamma_beam = E_beam/0.511
+    n_emitt_x = 3e-6
+    n_emitt_y = 0.5e-6
+    ene_sp = 0.1  # %
+    n_part = 1e5
+    sz0 = 1e-6  # gaussian decay
+    kp = np.sqrt(n_p_plateau * ct.e**2 / (ct.epsilon_0 * ct.m_e * ct.c**2))
+    kbeta = kp / np.sqrt(2. * gamma_beam)  # betatron wavenumber (blowout)
+    betax0 = 1. / kbeta   # matched beta
+    sx0 = np.sqrt(n_emitt_x * betax0 / gamma_beam)  # matched beam size (rms)
+    sy0 = np.sqrt(n_emitt_y * betax0 / gamma_beam)  # matched beam size (rms)
+
+    # Determine guiding channel.
+    r_e = ct.e**2 / (4. * np.pi * ct.epsilon_0 * ct.m_e * ct.c**2)
+    rel_delta_n_over_w2 = 1. / (np.pi * r_e * w0_laser**4 * n_p_plateau)
+
+    # Generate bunch
+    x, y, z, ux, uy, uz, q = trapezoidal_bunch(
+        i1_beam, i2_beam, n_part=n_part, gamma0=gamma_beam,
+        s_g=ene_sp * gamma_beam / 100, length=l_beam,
+        s_z=sz0, emit_x=n_emitt_x, s_x=sx0, emit_y=n_emitt_y, s_y=sy0, zf=0.,
+        tf=0.)
+    z -= l_beam/2 + z_beam
+    bunch = ParticleBunch(q, x, y, z, ux, uy, uz, name='bunch')
+
+    # Distance between right bounday and laser centroid.
+    dz_lb = 4. * ct.c * tau_laser
+
+    # Maximum radial extension of the plasma.
+    p_rmax = 2.5*w0_laser
+
+    # Box lenght.
+    l_p = ge.plasma_wavelength(n_p_plateau*1e-6)
+    l_box = dz_lb + 90e-6
+
+    # Number of diagnostics
+    n_out = 3
+
+    if task == 'fbpic':
+        run_fbpic(
+            a0, w0_laser, tau_laser, lambda0, bunch, n_p_plateau, l_plateau,
+            rel_delta_n_over_w2, p_rmax, dz_lb, l_box, n_out)
+    elif task == 'wake-t':
+        run_wake_t(
+            a0, w0_laser, tau_laser, lambda0, bunch, n_p_plateau, l_plateau,
+            rel_delta_n_over_w2, p_rmax, dz_lb, l_box, n_out-1)
+
+
+def determine_laser_a0(ene, tau_fwhm, w0, lambda0):
+    tau = tau_fwhm / np.sqrt(2. * np.log(2))
+    k0 = 2. * np.pi / lambda0  # Laser wavenumber
+    PA = ct.epsilon_0 * ct.c**5 * ct.m_e**2 / ct.e**2  # Power constant
+    P0 = ene / (np.sqrt(2 * np.pi) * (tau / 2))
+    i0 = P0 / ((np.pi / 2)* w0**2)
+    a0 = np.sqrt(i0 / (PA * k0**2 / 2))
+    return a0
+
+
+def density_profile(z):
+    # Allocate relative density
+    n = np.ones_like(z)
+    # Make zero before plateau
+    n = np.where(z < 0, 0, n)
+    # Make zero after plateau
+    n = np.where( z >= l_plateau, 0, n)
+    # Return absolute density
+    return n * n_p_plateau
+
+
+def run_wake_t(
+        a0, w0, tau_fwhm, lambda0, bunch, n_p, l_plasma, pc, p_rmax, dz_lb,
+        l_box, n_out):
+    
+    # Create laser.
+    laser = GaussianPulse(
+        xi_c=0., l_0=lambda0, w_0=w0, a_0=a0, tau=tau_fwhm, z_foc=0.)
+
+    # Plasma stage.
+    s_d = ge.plasma_skin_depth(n_p*1e-6)
+    dr = s_d / 20
+    dz = tau_fwhm * ct.c / 40
+    r_max = w0 * 4
+    plasma = PlasmaStage(
+        l_plasma,
+        density=density_profile,
+        wakefield_model='quasistatic_2d',
+        n_out=n_out,
+        laser=laser,
+        laser_evolution=True,
+        r_max=r_max,
+        r_max_plasma=p_rmax,
+        xi_min=dz_lb-l_box,
+        xi_max=dz_lb,
+        n_r=int(r_max / dr),
+        n_xi=int(l_box / dz),
+        dz_fields=l_box*2,
+        ppc=4,
+        parabolic_coefficient=pc,
+        max_gamma=25
+    )
+
+    # Do tracking.
+    plasma.track(bunch, opmd_diag=True, out_initial=True, diag_dir='diags')
+
+
+def run_fbpic(
+        a0, w0, tau_fwhm, lambda0, bunch, n_p, l_plasma, pc, p_rmax, dz_lb,
+        l_box, n_out):
+
+    use_cuda = True
+    n_order = -1
+
+    # Boosted frame
+    gamma_boost = 25.
+    boost = BoostConverter(gamma_boost)
+
+    # The laser (Gaussian)
+    lambda0 = 0.8e-6    # Laser wavelength
+    tau = tau_fwhm / np.sqrt(2. * np.log(2))  # Laser duration (2 sigmas) in intensity
+    ctau = tau * ct.c
+
+    # The simulation box
+    zmin = -l_box      # Left  edge of the simulation box (meters)
+    zmax = 0.e-6       # Right edge of the simulation box (meters)
+    rmax = w0 * 4
+    dz_adv = lambda0 / 40. /2  # Advised longitudinal resolution
+    Nz_adv = int(l_box / dz_adv)
+    Nz = Nz_adv     # Number of gridpoints along z
+    Nm = 3            # Number of modes used
+    s_d = ge.plasma_skin_depth(n_p*1e-6)
+    dr = s_d / 20
+    Nr = int(rmax / dr)
+
+    # Laser centroid
+    z0 = zmax - dz_lb
+
+    # The simulation timestep
+    dz = (zmax - zmin) / Nz
+    dt = dz / ct.c
+
+    # The moving window
+    v_window = ct.c     # velocity of the window
+
+    # Velocity of the Galilean frame (for suppression of the NCI)
+    v_comoving, = boost.velocity([0.])
+
+    # ------------
+
+    # The plasma particles
+    p_zmin = zmax    # Position of the beginning of the plasma (meters)
+    p_nz = 2         # Number of particles per cell along z
+    p_nr = 2         # Number of particles per cell along r
+    p_nt = 8         # Number of particles per cell along theta
+
+    # The interaction length of the simulation (meters)
+    L_lab_interact = l_plasma
+    # Interaction time (seconds) (to calculate number of PIC iterations)
+    T_lab_interact = (L_lab_interact + (zmax - zmin)) / v_window
+
+    T_lab_interact_plasma = L_lab_interact / v_window
+    # (i.e. the time it takes for the moving window to slide across the plasma)
+
+    # Number of discrete diagnostic snapshots in the lab frame
+    N_lab_diag = n_out
+
+    # data dumping period in dt units:
+    dt_lab_diag_period = T_lab_interact_plasma/(N_lab_diag-1)  # Period of the diagnostics (seconds)
+
+    # In boosted frame:
+    v_window_boosted, = boost.velocity([v_window])
+
+    # Interaction time in boosted frame
+    T_interact = boost.interaction_time( L_lab_interact, (zmax - zmin), v_window)
+
+    # Period of writing the cached backtransformed lab frame diagnostics to disk
+    # (in number of iterations)
+    write_period = 200
+
+    # Density function
+    def dens_func( z, r):
+        z_lab = z * gamma_boost
+        n = density_profile(z_lab) / n_p
+        n = n * (1. + pc * r**2)
+        return(n)
+
+    # External bunch
+    if bunch is not None:
+        x, y, z, px, py, pz, q = (
+            bunch.x, bunch.y, bunch.xi, bunch.px, bunch.py, bunch.pz, bunch.q)
+        w = np.abs(q / ct.e)
+        z += z0
+
+    # Initialize the simulation object
+    sim = Simulation(
+        Nz, zmax, Nr, rmax, Nm, dt, zmin=zmin,
+        v_comoving=v_comoving, gamma_boost=boost.gamma0,
+        n_order=n_order, use_cuda=use_cuda,
+        boundaries={'z': 'open', 'r': 'reflective'},
+        particle_shape='cubic')
+    
+    # Add the Helium ions (full pre-ionized: levels 1 and 2)
+    plasma_ions = sim.add_new_species(
+        q=ct.e, m=ct.m_p, n=n_p, dens_func=dens_func, p_nz=p_nz, p_nr=p_nr,
+        p_nt=p_nt, p_zmin=p_zmin, p_rmax=p_rmax)
+
+    # Plasma electrons: coming from helium
+    plasma_elec = sim.add_new_species(
+        q=-ct.e, m=ct.m_e, n=n_p, dens_func=dens_func, p_nz=p_nz, p_nr=p_nr,
+        p_nt=p_nt, p_zmin=p_zmin, p_rmax=p_rmax)
+
+    # Add an electron bunch
+    if bunch is not None:
+        add_particle_bunch_from_arrays(
+            sim, -ct.e, ct.m_e, x, y, z, px, py, pz, w,
+            boost=boost, z_injection_plane=0.)
+
+    # Add a laser to the fields of the simulation
+    add_laser(sim, a0, w0, ctau, z0, lambda0=lambda0, zf=0.,
+              gamma_boost=boost.gamma0, method='antenna', z0_antenna=0.,
+              cep_phase=np.pi)
+    
+    # Configure the moving window
+    sim.set_moving_window(v=v_window_boosted)
+
+    # Add diagnostics
+    write_dir = 'diags'
+
+    # Set start time of diagnostics to the exact moment the bunch enters the
+    # plasma. (Required to have output at same location as Wake-T)
+    if bunch is not None:
+        T_start_lab = (zmax - np.average(z)) / v_window
+    else:
+        T_start_lab = 0.
+
+    # Add diagnostics.
+    sim.diags = [
+        BackTransformedFieldDiagnostic(
+            zmin, zmax, v_window, T_start_lab, dt_lab_diag_period, N_lab_diag,
+            boost.gamma0, fieldtypes=['E', 'B', 'rho'], period=write_period,
+            fldobject=sim.fld, comm=sim.comm, write_dir=write_dir)]
+    if bunch is not None:
+        sim.diags += [
+        BackTransformedParticleDiagnostic(
+            zmin, zmax, v_window, T_start_lab, dt_lab_diag_period, N_lab_diag,
+            boost.gamma0, write_period, sim.fld, species={'bunch':sim.ptcl[2]},
+            comm=sim.comm, write_dir=write_dir)
+        ]
+
+    # Number of iterations to perform
+    N_step = int(T_interact / sim.dt) + write_period
+
+    # Run the simulation
+    sim.step(N_step)
+    print('')
+
+
+if __name__ == '__main__':
+    run_simulation()

--- a/examples/multi_model_mt/varying_parameters.py
+++ b/examples/multi_model_mt/varying_parameters.py
@@ -1,0 +1,10 @@
+from collections import OrderedDict
+
+# List the names of the varying parameters, and their range of value
+# The names must be the same as those used in 'template_fbpic_script.py'
+varying_parameters = OrderedDict({
+    'beam_i_1': [0.1, 10],  # kA
+    'beam_i_2': [0.1, 10],  # kA
+    'beam_z_i_2': [-10, 10],  # µm
+    'beam_length': [1, 20]  # µm
+})


### PR DESCRIPTION
This PR adds the multi-task example that combines Wake-T (low fidelity) and FBPIC (high fidelity) simulations. The physical case is an LPA with external injection, where the witness beam has a trapezoidal current profile. The four parameters to tune are the current at the head, current at the tail, beam length, and longitudinal position of the head.

The example includes a file `bunch_utils.py` made by @delaossa to generate the trapezoidal distribution. Also, in order to have the Wake-T and FBPIC diagnostics at exactly the same locations in the plasma, custom diagnostic classes for FBPIC have been defined in `custom_fld_diags.py` and `custom_ptcl_diags.py`. These classes add the option of specifying the start time of the backtransformed diagnostics so that we can get the output at the exact time the bunch enters (and exits) the plasma.

To install Wake-T, get the latest `dev` version as indicated [here](https://wake-t.readthedocs.io/en/latest/user_guide/installation.html#latest-development-version-from-github)