### PR TITLE
Fix memory issues in multitask generator

### DIFF
--- a/libe_opt/persistent_gp.py
+++ b/libe_opt/persistent_gp.py
@@ -651,11 +651,12 @@ def persistent_gp_mt_ax_gen_f(H, persis_info, gen_specs, libE_info):
                     break
                 except RuntimeError as e:
                     # Print exception.
-                    print('RuntimeError: {}'.format(e))
+                    print('RuntimeError: {}'.format(e), flush=True)
                     # Divide batch size by 2.
                     init_batch_limit //= 2
+                    print('Retrying with `init_batch_limit={}`'.format(
+                        init_batch_limit), flush=True)
                 finally:
-                    print(init_batch_limit)
                     # If all attempts have failed (even for batch size of 1),
                     # mark generation as failed and break loop.
                     if init_batch_limit == 0:


### PR DESCRIPTION
When having a large number or samples (≳1000), the multitask generator was typically crashing due to out-of-memory errors, especially when running on a GPU. The crash happens while generating the next batch of configurations to evaluate, at the point where the acquisition function is optimized. This optimization begins by evaluating the acquisition function at 1000 points in a single batch (by default), which can result in a matrix that is larger than the available memory.

This PR adds the option of evaluating these points in several batches, so that each batch can actually fit in memory. This is done by passing the `init_batch_limit` to `m.gen`. Initially, the generator tries to optimize the acquisition function with `init_batch_limit=1000`. If this triggers an out-of-memory error, `init_batch_limit` is divided by `2` and a new trial is attempted. This process is repeated until the generator runs successfully.

Related issues: https://github.com/pytorch/botorch/issues/366, https://github.com/cornellius-gp/gpytorch/issues/647, https://github.com/cornellius-gp/gpytorch/issues/1978.