### PR TITLE
Enable Sobol scrambling in multitask generator

### DIFF
--- a/libe_opt/persistent_gp.py
+++ b/libe_opt/persistent_gp.py
@@ -601,7 +601,7 @@ def persistent_gp_mt_ax_gen_f(H, persis_info, gen_specs, libE_info):
         if model_iteration == 0:
             # Initialize with sobol sample.
             for model, n_gen in zip([hifi_task, lofi_task], [n_init_hifi, n_init_lofi]):
-                s = get_sobol(exp.search_space, scramble=False)
+                s = get_sobol(exp.search_space, scramble=True)
                 gr = s.gen(n_gen)
                 trial = exp.new_batch_trial(trial_type=model, generator_run=gr)
                 trial.run()


### PR DESCRIPTION
This PR sets `scramble=True` in the `get_sobol` method of the multitask generator. This is actually the default behavior, but we had it set to `False` due to copying the code from the multitask example in the Ax documentation. With `scramble=True`, we now make sure that we get different configurations in the initialization every time we run an optimization. Otherwise, we always get the same ones. This behavior now matches that of the single-fidelity generator.