### PR TITLE
Speedup tests with new dependencies

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -31,11 +31,10 @@ jobs:
     - shell: bash -l {0}
       name: Install dependencies
       run: |
-        conda install mpich
-        conda install mpi4py
+        conda install numpy pandas pytorch cpuonly -c pytorch
+        conda install -c conda-forge mpi4py mpich
+        pip install .
         pip install flake8 pytest
-        pip install -r requirements.txt
-        python setup.py install
     - shell: bash -l {0}
       name: Lint with flake8
       run: |


### PR DESCRIPTION
This PR changes how the dependencies are installed for the automated tests. In particular, it installs pytorch from its conda channel. This version, as opposed to the one used previously, is already linked to MKL and results in a factor ~10 faster unit tests.