### PR TITLE
Fix missing modules in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,3 @@ Documentation = 'https://optimas.readthedocs.io/'
 
 [tool.setuptools.dynamic]
 version = {attr = "optimas.__version__"}
-
-[tool.setuptools.packages.find]
-where = ['optimas']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,3 +41,6 @@ Documentation = 'https://optimas.readthedocs.io/'
 
 [tool.setuptools.dynamic]
 version = {attr = "optimas.__version__"}
+
+[tool.setuptools]
+packages = ['optimas']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,5 +42,8 @@ Documentation = 'https://optimas.readthedocs.io/'
 [tool.setuptools.dynamic]
 version = {attr = "optimas.__version__"}
 
-[tool.setuptools]
-packages = ['optimas']
+[tool.setuptools.packages.find]
+include = [
+    'optimas',
+    'optimas.*',
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,4 @@ Documentation = 'https://optimas.readthedocs.io/'
 version = {attr = "optimas.__version__"}
 
 [tool.setuptools.packages.find]
-include = [
-    'optimas',
-]
+where = ['optimas']


### PR DESCRIPTION
All the submodules in `optimas` where missing when installing with `pip` because they where not included in `[tool.setuptools.packages.find]`. This PR fixes that.