### PR TITLE
Fail docs on warning

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,7 @@ build:
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: doc/source/conf.py
+   fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF
 formats:


### PR DESCRIPTION
The docs build will now fail if any warning is raised. This prevents any issues (e.g., with formatting) that would otherwise not be noticed.