### PR TITLE
Pin libensemble version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
 ]
 dependencies = [
-    'libensemble >= 0.9.2',
+    'libensemble == 0.9.3',
     'jinja2',
     'ax-platform >= 0.2.9',
     'mpi4py',


### PR DESCRIPTION
It seems that the tests are currently failing due to the new release of libEnsemble. This PR pins the libEnsemble version on the `main` branch to `0.9.3` until we are ready to upgrade to `0.10`.