### PR TITLE
Fix bug with executable in `sim_files`

### DIFF
--- a/optimas/explorations/base.py
+++ b/optimas/explorations/base.py
@@ -74,10 +74,10 @@ class Exploration():
             self.history_save_period = history_save_period
         self.exploration_dir_path = exploration_dir_path
         self.libe_comms = libe_comms
-        self._set_default_libe_specs()
         self._create_alloc_specs()
         self._create_executor()
         self._initialize_evaluator()
+        self._set_default_libe_specs()
 
     def run(self) -> None:
         """Run the exploration."""


### PR DESCRIPTION
A bug in the order with which the `Exploration` is initialized was preventing the `executable` provided to the `TemplateEvaluator` from being added to the `sim_files` list.

Fixes #97 