### PR TITLE
Change instructions to install from PyPI and add post-release badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,6 @@
 [![tests badge](https://github.com/optimas-org/optimas/actions/workflows/unix.yml/badge.svg)](https://github.com/optimas-org/optimas/actions)
 [![Documentation Status](https://readthedocs.org/projects/optimas/badge/?version=latest)](https://optimas.readthedocs.io/en/latest/?badge=latest)
 [![DOI](https://zenodo.org/badge/287560975.svg)](https://zenodo.org/badge/latestdoi/287560975)
+[![License](https://img.shields.io/pypi/l/optimas.svg)](license.txt)
 
 Optimas is a Python library for scalable optimization on massively-parallel supercomputers. See the [documentation](https://optimas.readthedocs.io/) for installation instructions, tutorials, and more information.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 <!-- <hr/> -->
 
 # Optimization at scale, powered by [libEnsemble](https://libensemble.readthedocs.io/)
+[![PyPI](https://img.shields.io/pypi/v/optimas)](https://pypi.org/project/optimas/)
+[![tests badge](https://github.com/optimas-org/optimas/actions/workflows/unix.yml/badge.svg)](https://github.com/optimas-org/optimas/actions)
 [![Documentation Status](https://readthedocs.org/projects/optimas/badge/?version=latest)](https://optimas.readthedocs.io/en/latest/?badge=latest)
+[![DOI](https://zenodo.org/badge/287560975.svg)](https://zenodo.org/badge/latestdoi/287560975)
 
 Optimas is a Python library for scalable optimization on massively-parallel supercomputers. See the [documentation](https://optimas.readthedocs.io/) for installation instructions, tutorials, and more information.

--- a/doc/source/user_guide/installation_local.rst
+++ b/doc/source/user_guide/installation_local.rst
@@ -57,8 +57,8 @@ On Windows:
 
 Install Optimas
 ~~~~~~~~~~~~~~~
-Install the latest version directly from GitHub:
+Install the latest release from PyPI
 
 .. code::
 
-    pip install git+https://github.com/optimas-org/optimas.git
+    pip install optimas

--- a/doc/source/user_guide/installation_maxwell.rst
+++ b/doc/source/user_guide/installation_maxwell.rst
@@ -55,7 +55,7 @@ Install ``optimas``
 
 .. code::
 
-    pip install git+https://github.com/optimas-org/optimas.git
+    pip install optimas
 
 
 Installing FBPIC and Wake-T (optional)

--- a/doc/source/user_guide/installation_perlmutter.rst
+++ b/doc/source/user_guide/installation_perlmutter.rst
@@ -17,10 +17,7 @@ environment, in which to install `optimas`.
     python3 -m venv $HOME/sw/perlmutter/gpu/venvs/optimas
     source $HOME/sw/perlmutter/gpu/venvs/optimas/bin/activate
 
-    python3 -m pip install torch
-    git clone git@github.com:optimas-org/optimas.git $HOME/src/optimas
-    cd $HOME/src/optimas
-    python3 -m pip install .
+    python3 -m pip install optimas
 
 Running
 ~~~~~~~


### PR DESCRIPTION
- Updates installation instructions to use the PyPI releases instead of the Github repo. (@ax3l, @RemiLehe, I removed the `pip install torch` line from the Perlmutter instructions because this dependency is already installed when doing `pip install optimas`. This works well on my side, at least on Maxwell).
- Add PyPI, Zenodo, license and tests badges.