### PR TITLE
Implement generator with user-defined `AxClient`

### DIFF
--- a/doc/source/api/generators.rst
+++ b/doc/source/api/generators.rst
@@ -12,3 +12,4 @@ Generators
     AxSingleFidelityGenerator
     AxMultiFidelityGenerator
     AxMultitaskGenerator
+    AxClientGenerator

--- a/optimas/generators/__init__.py
+++ b/optimas/generators/__init__.py
@@ -1,5 +1,6 @@
 from .ax.service.single_fidelity import AxSingleFidelityGenerator
 from .ax.service.multi_fidelity import AxMultiFidelityGenerator
+from .ax.service.ax_client import AxClientGenerator
 from .ax.developer.multitask import AxMultitaskGenerator
 from .grid_sampling import GridSamplingGenerator
 from .line_sampling import LineSamplingGenerator
@@ -7,5 +8,6 @@ from .random_sampling import RandomSamplingGenerator
 
 
 __all__ = ['AxSingleFidelityGenerator', 'AxMultiFidelityGenerator',
-           'AxMultitaskGenerator', 'GridSamplingGenerator',
-           'LineSamplingGenerator', 'RandomSamplingGenerator']
+           'AxMultitaskGenerator', 'AxClientGenerator',
+           'GridSamplingGenerator', 'LineSamplingGenerator',
+           'RandomSamplingGenerator']

--- a/optimas/generators/ax/service/ax_client.py
+++ b/optimas/generators/ax/service/ax_client.py
@@ -49,9 +49,9 @@ class AxClientGenerator(AxServiceGenerator):
     -----
     If the ``AxClient`` contains ``outcome_constraints``, these will appear in
     the ``optimas`` log as optimization objectives. They are still being
-    correctly used as constrains by the ``AxClient``, and the optimization
+    correctly used as constraints by the ``AxClient``, and the optimization
     will work as expected. This is only an issue on ``optimas``, which fails to
-    properly recognize them because optimization constrains have not yet been
+    properly recognize them because optimization constraints have not yet been
     implemented.
     """
     def __init__(
@@ -123,10 +123,10 @@ class AxClientGenerator(AxServiceGenerator):
         objectives: List[Objective],
         ax_client: AxClient
     ):
-        """Add outcome constrains in the AxClient to the list of objectives.
+        """Add outcome constraints in the AxClient to the list of objectives.
 
         This is currently needed because optimas does not yet have a
-        proper definition of constrains. The constrains will be correctly
+        proper definition of constraints. The constraints will be correctly
         handled and given to the AxClient, but will appear as objectives
         in the optimization log.
         """

--- a/optimas/generators/ax/service/ax_client.py
+++ b/optimas/generators/ax/service/ax_client.py
@@ -32,7 +32,7 @@ class AxClientGenerator(AxServiceGenerator):
     dedicated_resources : bool, optional
         Whether to allocated dedicated resources (e.g., the GPU) for the
         generator. These resources will not be available to the
-        simulation workers. By default, ``True``.
+        simulation workers. By default, ``False``.
         This parameter will only have an effect if any ``GenerationStep`` in
         the ``AxClient`` uses a GPU.
     save_model : bool, optional
@@ -59,7 +59,7 @@ class AxClientGenerator(AxServiceGenerator):
         ax_client: AxClient,
         analyzed_parameters: Optional[List[Parameter]] = None,
         gpu_id: Optional[int] = 0,
-        dedicated_resources: Optional[bool] = True,
+        dedicated_resources: Optional[bool] = False,
         save_model: Optional[bool] = True,
         model_save_period: Optional[int] = 5,
         model_history_dir: Optional[str] = 'model_history',

--- a/optimas/generators/ax/service/ax_client.py
+++ b/optimas/generators/ax/service/ax_client.py
@@ -1,0 +1,152 @@
+"""Contains the definition of the Ax generator that uses a custom AxClient."""
+from typing import List, Optional
+
+from ax.service.ax_client import AxClient
+from ax.core.objective import MultiObjective
+
+from optimas.core import Objective, VaryingParameter, Parameter
+from .base import AxServiceGenerator
+
+
+class AxClientGenerator(AxServiceGenerator):
+    """Bayesian optimization generator with a user-defined ``AxClient``.
+
+    This generator allows the user to provide a custom ``AxClient``,
+    allowing for maximum control of the optimization.
+
+    For this generator there is no need to provide the list of
+    ``varying_parameters`` or ``objectives``. The generator will obtain
+    these parameters directly from the ``AxClient``.
+
+    Parameters
+    ----------
+    ax_client : AxClient
+        The Ax client from which the trials will be generated.
+    analyzed_parameters : list of Parameter, optional
+        List of parameters to analyze at each trial, but which are not
+        optimization objectives. By default ``None``.
+    gpu_id : int, optional
+        The ID of the GPU in which to run the generator. By default, ``0``.
+        This parameter will only have an effect if any of the
+        ``GenerationStep``s in the ``AxClient`` uses a GPU.
+    dedicated_resources : bool, optional
+        Whether to allocated dedicated resources (e.g., the GPU) for the
+        generator. These resources will not be available to the
+        simulation workers. By default, ``True``.
+        This parameter will only have an effect if any of the
+        ``GenerationStep``s in the ``AxClient`` uses a GPU.
+    save_model : bool, optional
+        Whether to save the optimization model (in this case, the Ax client) to
+        disk. By default ``True``.
+    model_save_period : int, optional
+        Periodicity, in number of evaluated Trials, with which to save the
+        model to disk. By default, ``5``.
+    model_history_dir : str, optional
+        Name of the directory in which the model will be saved. By default,
+        ``'model_history'``.
+
+    Notes
+    -----
+    If the ``AxClient`` contains ``outcome_constraints``, these will appear in
+    the ``optimas`` log as optimization objectives. They are still being
+    correctly used as constrains by the ``AxClient``, and the optimization
+    will work as expected. This is only an issue on ``optimas``, which fails to
+    properly recognize them because optimization constrains have not yet been
+    implemented.
+    """
+    def __init__(
+        self,
+        ax_client: AxClient,
+        analyzed_parameters: Optional[List[Parameter]] = None,
+        gpu_id: Optional[int] = 0,
+        dedicated_resources: Optional[bool] = True,
+        save_model: Optional[bool] = True,
+        model_save_period: Optional[int] = 5,
+        model_history_dir: Optional[str] = 'model_history',
+    ):
+        varying_parameters = self._get_varying_parameters(ax_client)
+        objectives = self._get_objectives(ax_client)
+        self._add_constraints_to_objectives(objectives, ax_client)
+        use_cuda = self._use_cuda(ax_client)
+        self._ax_client = ax_client
+        super().__init__(
+            varying_parameters=varying_parameters,
+            objectives=objectives,
+            analyzed_parameters=analyzed_parameters,
+            use_cuda=use_cuda,
+            gpu_id=gpu_id,
+            dedicated_resources=dedicated_resources,
+            save_model=save_model,
+            model_save_period=model_save_period,
+            model_history_dir=model_history_dir
+        )
+
+    def _get_varying_parameters(
+        self,
+        ax_client: AxClient
+    ):
+        """Obtain the list of varying parameters from the AxClient."""
+        varying_parameters = []
+        for _, p in ax_client.experiment.search_space.parameters.items():
+            vp = VaryingParameter(
+                name=p.name,
+                lower_bound=p.lower,
+                upper_bound=p.upper,
+                is_fidelity=p.is_fidelity,
+                fidelity_target_value=p.target_value,
+                dtype=p.python_type
+            )
+            varying_parameters.append(vp)
+        return varying_parameters
+
+    def _get_objectives(
+        self,
+        ax_client: AxClient
+    ):
+        """Obtain the list of objectives from the AxClient."""
+        objectives = []
+        ax_objective = ax_client.experiment.optimization_config.objective
+        if isinstance(ax_objective, MultiObjective):
+            ax_objectives = ax_objective.objectives
+        else:
+            ax_objectives = [ax_objective]
+        for ax_obj in ax_objectives:
+            obj = Objective(
+                name=ax_obj.metric_names[0],
+                minimize=ax_obj.minimize
+            )
+            objectives.append(obj)
+        return objectives
+
+    def _add_constraints_to_objectives(
+        self,
+        objectives: List[Objective],
+        ax_client: AxClient
+    ):
+        """Add outcome constrains in the AxClient to the list of objectives.
+
+        This is currently needed because optimas does not yet have a
+        proper definition of constrains. The constrains will be correctly
+        handled and given to the AxClient, but will appear as objectives
+        in the optimization log.
+        """
+        ax_config = ax_client.experiment.optimization_config
+        for constraint in ax_config.outcome_constraints:
+            objectives.append(
+                Objective(name=constraint.metric.name)
+            )
+
+    def _create_ax_client(self) -> AxClient:
+        """Overrides the base function to simply return the given"""
+        return self._ax_client
+
+    def _use_cuda(
+        self,
+        ax_client: AxClient
+    ):
+        """Determine whether the AxClient uses CUDA."""
+        for step in ax_client.generation_strategy._steps:
+            if "torch_device" in step.model_kwargs:
+                if step.model_kwargs["torch_device"] == "cuda":
+                    return True
+        return False

--- a/optimas/generators/ax/service/ax_client.py
+++ b/optimas/generators/ax/service/ax_client.py
@@ -27,14 +27,14 @@ class AxClientGenerator(AxServiceGenerator):
         optimization objectives. By default ``None``.
     gpu_id : int, optional
         The ID of the GPU in which to run the generator. By default, ``0``.
-        This parameter will only have an effect if any of the
-        ``GenerationStep``s in the ``AxClient`` uses a GPU.
+        This parameter will only have an effect if any ``GenerationStep`` in
+        the ``AxClient`` uses a GPU.
     dedicated_resources : bool, optional
         Whether to allocated dedicated resources (e.g., the GPU) for the
         generator. These resources will not be available to the
         simulation workers. By default, ``True``.
-        This parameter will only have an effect if any of the
-        ``GenerationStep``s in the ``AxClient`` uses a GPU.
+        This parameter will only have an effect if any ``GenerationStep`` in
+        the ``AxClient`` uses a GPU.
     save_model : bool, optional
         Whether to save the optimization model (in this case, the Ax client) to
         disk. By default ``True``.


### PR DESCRIPTION
This PR adds a new generator that allows the user to provide a custom `AxClient`. This allows for maximum tunability and control of the optimization.

Note: If the ``AxClient`` contains ``outcome_constraints``, these will appear in the ``optimas`` log as optimization objectives. They are still being correctly used as constraints by the ``AxClient``, and the optimization will work as expected. This is only an issue on ``optimas``, which fails to properly recognize them because optimization constraints have not yet been implemented.