### PR TITLE
Update generator after running exploration

### DIFF
--- a/optimas/explorations/base.py
+++ b/optimas/explorations/base.py
@@ -67,13 +67,13 @@ class Exploration():
         self.max_evals = max_evals
         self.sim_workers = sim_workers
         self.run_async = run_async
-        self.history = self._load_history(history)
         if history_save_period is None:
             self.history_save_period = sim_workers
         else:
             self.history_save_period = history_save_period
         self.exploration_dir_path = exploration_dir_path
         self.libe_comms = libe_comms
+        self._load_history(history)
         self._create_alloc_specs()
         self._create_executor()
         self._initialize_evaluator()
@@ -98,10 +98,6 @@ class Exploration():
             self.generator.objectives,
             self.generator.analyzed_parameters
         )
-
-        # If provided, incorporate history into generator.
-        if self.history is not None:
-            self.generator.incorporate_history(self.history)
 
         # Launch exploration with libEnsemble.
         history, persis_info, flag = libE(
@@ -141,7 +137,10 @@ class Exploration():
         """Initialize exploration evaluator."""
         self.evaluator.initialize()
 
-    def _load_history(self, history: Union[str, np.ndarray, None]) -> None:
+    def _load_history(
+        self,
+        history: Union[str, np.ndarray, None]
+    ) -> None:
         """Load history file."""
         if isinstance(history, str):
             if os.path.exists(history):
@@ -155,7 +154,10 @@ class Exploration():
         assert history is None or isinstance(history, np.ndarray), (
             'Type {} not valid for `history`'.format(type(history))
         )
-        return history
+        # Incorporate history into generator.
+        if history is not None:
+            self.generator.incorporate_history(history)
+        self.history = history
 
     def _set_default_libe_specs(self) -> None:
         """Set default exploration libe_specs."""

--- a/optimas/explorations/base.py
+++ b/optimas/explorations/base.py
@@ -118,7 +118,7 @@ class Exploration():
         self.history = history
 
         # Update generator with the one received from libE.
-        self.generator.update(persis_info[1]['generator'])
+        self.generator._update(persis_info[1]['generator'])
 
         # Determine if current rank is master.
         if self.libE_specs["comms"] == "local":

--- a/optimas/explorations/base.py
+++ b/optimas/explorations/base.py
@@ -117,6 +117,9 @@ class Exploration():
         # Update history.
         self.history = history
 
+        # Update generator with the one received from libE.
+        self.generator.update(persis_info[1]['generator'])
+
         # Determine if current rank is master.
         if self.libE_specs["comms"] == "local":
             is_master = True

--- a/optimas/gen_functions.py
+++ b/optimas/gen_functions.py
@@ -1,5 +1,4 @@
 import os
-from copy import deepcopy
 
 import numpy as np
 from libensemble.message_numbers import (
@@ -91,6 +90,7 @@ def persistent_generator(H, persis_info, gen_specs, libE_info):
             number_of_gen_points = 0
 
     # Add updated generator to `persis_info`.
-    persis_info['generator'] = deepcopy(generator)
+    generator._prepare_to_send()
+    persis_info['generator'] = generator
 
     return H_o, persis_info, FINISHED_PERSISTENT_GEN_TAG

--- a/optimas/gen_functions.py
+++ b/optimas/gen_functions.py
@@ -89,4 +89,7 @@ def persistent_generator(H, persis_info, gen_specs, libE_info):
         else:
             number_of_gen_points = 0
 
+    # Add updated generator to `persis_info`.
+    persis_info['generator'] = generator
+
     return H_o, persis_info, FINISHED_PERSISTENT_GEN_TAG

--- a/optimas/gen_functions.py
+++ b/optimas/gen_functions.py
@@ -1,4 +1,5 @@
 import os
+from copy import deepcopy
 
 import numpy as np
 from libensemble.message_numbers import (
@@ -90,6 +91,6 @@ def persistent_generator(H, persis_info, gen_specs, libE_info):
             number_of_gen_points = 0
 
     # Add updated generator to `persis_info`.
-    persis_info['generator'] = generator
+    persis_info['generator'] = deepcopy(generator)
 
     return H_o, persis_info, FINISHED_PERSISTENT_GEN_TAG

--- a/optimas/generators/ax/developer/multitask.py
+++ b/optimas/generators/ax/developer/multitask.py
@@ -440,7 +440,7 @@ class AxMultitaskGenerator(AxGenerator):
             encoder_registry=self._encoder_registry
         )
 
-    def _prepare_to_send(self):
+    def _prepare_to_send(self) -> None:
         """Prepare generator to send to another process.
 
         Delete stored generator run. It can contain pytorch tensors that

--- a/optimas/generators/ax/developer/multitask.py
+++ b/optimas/generators/ax/developer/multitask.py
@@ -117,6 +117,7 @@ class AxMultitaskGenerator(AxGenerator):
         self.returned_hifi_trials = 0
         self.init_batch_limit = 1000
         self.current_trial = None
+        self.gr_lofi = None
         self._experiment = self._create_experiment()
 
     def get_gen_specs(
@@ -438,6 +439,15 @@ class AxMultitaskGenerator(AxGenerator):
             filepath=file_path,
             encoder_registry=self._encoder_registry
         )
+
+    def _prepare_to_send(self):
+        """Prepare generator to send to another process.
+
+        Delete stored generator run. It can contain pytorch tensors that
+        prevent serialization.
+        """
+        del self.gr_lofi
+        self.gr_lofi = None
 
 
 def max_utility_from_GP(

--- a/optimas/generators/ax/service/base.py
+++ b/optimas/generators/ax/service/base.py
@@ -125,9 +125,8 @@ class AxServiceGenerator(AxGenerator):
         pytorch tensors that prevent serialization.
         """
         generation_strategy = self._ax_client.generation_strategy
-        if hasattr(generation_strategy._curr.model_spec, '_fitted_model'):
+        if generation_strategy._model is not None:
             del generation_strategy._curr.model_spec._fitted_model
             generation_strategy._curr.model_spec._fitted_model = None
-        if hasattr(generation_strategy, '_model'):
             del generation_strategy._model
             generation_strategy._model = None

--- a/optimas/generators/ax/service/base.py
+++ b/optimas/generators/ax/service/base.py
@@ -6,6 +6,7 @@ import os
 
 from ax.service.ax_client import AxClient
 
+from optimas.utils.other import update_object
 from optimas.core import Objective, Trial, VaryingParameter, Parameter
 from optimas.generators.ax.base import AxGenerator
 from optimas.generators.base import Generator
@@ -148,6 +149,5 @@ class AxServiceGenerator(AxGenerator):
         """
         original_ax_client = self._ax_client
         super()._update(new_generator)
-        for key, value in vars(new_generator._ax_client).items():
-            setattr(original_ax_client, key, value)
+        update_object(original_ax_client, new_generator._ax_client)
         self._ax_client = original_ax_client

--- a/optimas/generators/ax/service/base.py
+++ b/optimas/generators/ax/service/base.py
@@ -118,7 +118,7 @@ class AxServiceGenerator(AxGenerator):
         )
         self._ax_client.save_to_json_file(file_path)
 
-    def _prepare_to_send(self):
+    def _prepare_to_send(self) -> None:
         """Prepare generator to send to another process.
 
         Delete the fitted model from the generation strategy. It can contain

--- a/optimas/generators/ax/service/base.py
+++ b/optimas/generators/ax/service/base.py
@@ -125,7 +125,9 @@ class AxServiceGenerator(AxGenerator):
         pytorch tensors that prevent serialization.
         """
         generation_strategy = self._ax_client.generation_strategy
-        del generation_strategy._curr.model_spec._fitted_model
-        del generation_strategy._model
-        generation_strategy._model = None
-        generation_strategy._curr.model_spec._fitted_model = None
+        if hasattr(generation_strategy._curr.model_spec, '_fitted_model'):
+            del generation_strategy._curr.model_spec._fitted_model
+            generation_strategy._curr.model_spec._fitted_model = None
+        if hasattr(generation_strategy, '_model'):
+            del generation_strategy._model
+            generation_strategy._model = None

--- a/optimas/generators/ax/service/base.py
+++ b/optimas/generators/ax/service/base.py
@@ -117,3 +117,15 @@ class AxServiceGenerator(AxGenerator):
                 self._n_completed_trials_last_saved)
         )
         self._ax_client.save_to_json_file(file_path)
+
+    def _prepare_to_send(self):
+        """Prepare generator to send to another process.
+
+        Delete the fitted model from the generation strategy. It can contain
+        pytorch tensors that prevent serialization.
+        """
+        generation_strategy = self._ax_client.generation_strategy
+        del generation_strategy._curr.model_spec._fitted_model
+        del generation_strategy._model
+        generation_strategy._model = None
+        generation_strategy._curr.model_spec._fitted_model = None

--- a/optimas/generators/ax/service/base.py
+++ b/optimas/generators/ax/service/base.py
@@ -8,6 +8,7 @@ from ax.service.ax_client import AxClient
 
 from optimas.core import Objective, Trial, VaryingParameter, Parameter
 from optimas.generators.ax.base import AxGenerator
+from optimas.generators.base import Generator
 
 
 class AxServiceGenerator(AxGenerator):
@@ -130,3 +131,23 @@ class AxServiceGenerator(AxGenerator):
             generation_strategy._curr.model_spec._fitted_model = None
             del generation_strategy._model
             generation_strategy._model = None
+
+    def _update(
+        self,
+        new_generator: Generator
+    ) -> None:
+        """Update generator with the attributes of a newer one.
+
+        This method is overrides the base one to make sure that the original
+        AxClient is updated and not simply replaced.
+
+        Parameters
+        ----------
+        new_generator : Generator
+            The newer version of the generator returned in ``persis_info``.
+        """
+        original_ax_client = self._ax_client
+        super()._update(new_generator)
+        for key, value in vars(new_generator._ax_client).items():
+            setattr(original_ax_client, key, value)
+        self._ax_client = original_ax_client

--- a/optimas/generators/base.py
+++ b/optimas/generators/base.py
@@ -7,6 +7,7 @@ from typing import List, Dict, Optional
 import numpy as np
 
 from optimas.utils.logger import get_logger
+from optimas.utils.other import update_object
 from optimas.gen_functions import persistent_generator
 from optimas.core import (Objective, Trial, Evaluation, VaryingParameter,
                           Parameter, TrialParameter)
@@ -318,8 +319,7 @@ class Generator():
         new_generator : Generator
             The newer version of the generator returned in ``persis_info``.
         """
-        for key, value in vars(new_generator).items():
-            setattr(self, key, value)
+        update_object(self, new_generator)
 
     def _ask(
         self,

--- a/optimas/generators/base.py
+++ b/optimas/generators/base.py
@@ -1,5 +1,6 @@
 """Contains the definition of the base Generator class."""
 
+from __future__ import annotations
 import os
 from typing import List, Dict, Optional
 
@@ -284,7 +285,22 @@ class Generator():
         libE_specs = {}
         return libE_specs
 
-    def update(self, new_generator):
+    def _update(
+        self,
+        new_generator: Generator
+    ):
+        """Update generator with the attributes of a newer one.
+
+        This method is only intended to be used internally by an
+        ``Exploration`` after a run is completed. It is needed because the
+        ``Generator`` given to ``libEnsemble`` is passed as a copy to the
+        generator worker and is therefore not updated during the run.
+
+        Parameters
+        ----------
+        new_generator : Generator
+            The newer version of the generator returned in ``persis_info``.
+        """
         for key, value in vars(new_generator).items():
             setattr(self, key, value)
 

--- a/optimas/generators/base.py
+++ b/optimas/generators/base.py
@@ -286,7 +286,7 @@ class Generator():
         libE_specs = {}
         return libE_specs
 
-    def _prepare_to_send(self):
+    def _prepare_to_send(self) -> None:
         """Prepare generator to send to another process.
 
         This method is necessary because the generator, when given to
@@ -305,7 +305,7 @@ class Generator():
     def _update(
         self,
         new_generator: Generator
-    ):
+    ) -> None:
         """Update generator with the attributes of a newer one.
 
         This method is only intended to be used internally by an

--- a/optimas/generators/base.py
+++ b/optimas/generators/base.py
@@ -251,6 +251,7 @@ class Generator():
         sim_workers : int
             Total number of parallel simulation workers.
         """
+        self._prepare_to_send()
         gen_specs = {
             # Generator function.
             'gen_f': self._gen_function,
@@ -284,6 +285,22 @@ class Generator():
         """Get the libEnsemble libe_specs."""
         libE_specs = {}
         return libE_specs
+
+    def _prepare_to_send(self):
+        """Prepare generator to send to another process.
+
+        This method is necessary because the generator, when given to
+        libEnsemble, is sent to another process (the process of the generator
+        worker) and then sent back to optimas at the end of the run. In order
+        for it to be sent, the generator must be serialized, and sometimes
+        some of the contents of the generator cannot be serialized. The
+        purpose of this method is to take care of the attributes that prevent
+        serialization, and is always called before the generator is sent
+        to/from libEnsemble.
+
+        It must be implemented by the subclasses, if needed.
+        """
+        pass
 
     def _update(
         self,

--- a/optimas/generators/base.py
+++ b/optimas/generators/base.py
@@ -284,6 +284,10 @@ class Generator():
         libE_specs = {}
         return libE_specs
 
+    def update(self, new_generator):
+        for key, value in vars(new_generator).items():
+            setattr(self, key, value)
+
     def _ask(
         self,
         trials: List[Trial]

--- a/optimas/utils/other.py
+++ b/optimas/utils/other.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+
+def update_object(
+    object_old: Any,
+    object_new: Any
+) -> None:
+    """Update the attributes of an object with those from a newer one.
+
+    This method is intended to be used with objects of the same type and that
+    have a `__dict__` attribute.
+
+    Parameters
+    ----------
+    object_old : Any
+        The object to be updated.
+    object_new : Any
+        The object from which to get the updated attributes.
+    """
+    assert isinstance(object_new, type(object_old)), "Object types don't match"
+    for key, value in vars(object_new).items():
+        setattr(object_old, key, value)

--- a/tests/test_ax_generators.py
+++ b/tests/test_ax_generators.py
@@ -42,7 +42,10 @@ def eval_func_task_2(input_params, output_params):
 
 
 def test_ax_single_fidelity():
-    """Test that an exploration with a single-fidelity generator runs"""
+    """
+    Test that an exploration with a single-fidelity generator runs
+    and that the generator and Ax client are updated after running.
+    """
 
     var1 = VaryingParameter('x0', -50., 5.)
     var2 = VaryingParameter('x1', -5., 15.)
@@ -58,7 +61,18 @@ def test_ax_single_fidelity():
         exploration_dir_path='./tests_output/test_ax_single_fidelity'
     )
 
+    # Get reference to original AxClient.
+    ax_client = gen._ax_client
+
+    # Run exploration.
     exploration.run()
+
+    # Check that the generator has been updated.
+    assert len(gen._trials) == exploration.history.shape[0]
+
+    # Check that the original ax client has been updated.
+    n_ax_trials = ax_client.get_trials_data_frame().shape[0]
+    assert n_ax_trials == exploration.history.shape[0]
 
     # Save history for later restart test
     np.save('./tests_output/ax_sf_history' , exploration.history)


### PR DESCRIPTION
The `Generator` stores a list of all the generated trials, as well as the underlying surrogate model (if any). However, this information was so far only available within the `gen_function` of `libEnsemble` and was not being given back to `optimas`. This is because the generator given to `libE` in the `gen_specs` is passed to the generator worker as a copy (because this worker is in a different process), and therefore the original one created by the user was not being updated (see related issue https://github.com/Libensemble/libensemble/issues/975). This is a problem, because in principle we could allow the user to inspect the generator after a run is completed to look at the surrogate model, trials, etc.

This PR implements a solution that consists on returning the copy of the generator contained by libEnsemble by adding it to the `persis_info` dictionary that `libE` returns. This copy is then used to update all attributes of the original generator.

Additional changes:
- In order to send the generator from libEnsemble back to optimas it must be serialized. Some generators (namely those for Bayesian optimization) had problems with this because some pytorch tensors could not be serialized. To handle this, a new method `Generator._prepare_to_send` has been added that is always called before the generator is sent. The `Generator` subclasses can implement this method to e.g., delete unnecessary non-serializable attributes.
- If a history array is given to the `Exploration`, these past observations will be given to the generator in `Exploration.__init__` instead of `Exploration.run`, which is what was being done until now. This should allow us to call `Exploration.run` several times without duplicating data in the generator. A use case for this is to allow the user to, e.g., run 50 evaluations, check the surrogate model in the generator, decide whether to tune any hyperparameters, run 50 more evaluations with the updated hyperparameters, and so on.