### PR TITLE
Add installation instructions for JUWELS Booster

### DIFF
--- a/doc/source/user_guide/installation_juwels.rst
+++ b/doc/source/user_guide/installation_juwels.rst
@@ -1,2 +1,109 @@
-Installation on Juwels (JSC)
-----------------------------
+Installation on JUWELS Booster (JSC)
+------------------------------------
+
+Log into a JUWELS booster node either with ``ssh`` or by opening a terminal
+in the `JupyterLabs <https://jupyter-jsc.fz-juelich.de/>`_ (choose JUWELS as
+system and LoginNodeBooster as Partition).
+
+
+Create a ``profile.optimas`` file in your home directory with the following content
+
+.. code::
+
+    module purge
+    module load Stages/2023
+    module load GCC
+    module load ParaStationMPI
+    module load CUDA
+    module load SciPy-bundle
+    module load mpi4py
+
+you can do this from the command line by executing ``cat > ~/profile.optimas`` and
+pasting the lines above. To save the file, finalize by pressing ``Ctrl+D``.
+
+Load the source file
+
+.. code::
+
+    source ~/profile.optimas
+
+
+Create a new environment for optimas
+
+.. code::
+
+    python -m venv $PROJECT/<username>/pyenvs/optimas_env
+
+
+Activate the environment
+
+.. code::
+
+    source $PROJECT/<username>/pyenvs/optimas_env/bin/activate
+
+
+Install ``optimas``
+
+.. code::
+
+    pip install optimas
+
+
+Installing FBPIC and Wake-T (optional)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+A common use case for ``optimas`` is to optimize the output of a plasma acceleration
+simulation with FBPIC or Wake-T (or both). If you need any of these tools, you
+can follow the instructions below to install them in your ``optimas_env``
+environment.
+
+Install FBPIC:
+
+.. code::
+
+    pip install cupy-cuda117
+    pip install fbpic
+
+
+Install Wake-T:
+
+.. code::
+
+    pip install Wake-T
+
+Install openPMD-viewer for data analysis
+
+.. code::
+
+    pip install openPMD-viewer
+
+
+Running an optimas job
+~~~~~~~~~~~~~~~~~~~~~~
+The following script can be used to submit an ``optimas`` job to the JUWELS
+booster (i.e., the ``booster`` partition). For testing, use the
+``develbooster`` partition instead. This script assumes that you
+need one node with 4 GPUs and that your optimas script is called
+``run_optimization.py``.
+
+Make sure to replace ``project_account``, ``user_email`` and ``username`` with
+your data.
+
+.. code::
+
+    #!/bin/bash
+
+    #SBATCH --job-name optimas
+    #SBATCH --nodes=1
+    #SBATCH --partition=booster
+    #SBATCH --account=<project_account>
+    #SBATCH --time=12:00:00
+    #SBATCH --output=stdout
+    #SBATCH --error=stderr
+    #SBATCH --mail-type=END
+    #SBATCH --mail-user=<user_email>
+
+    # Activate environment
+    source ~/profile.optimas
+    source $PROJECT/<username>/pyenvs/optimas_env/bin/activate
+
+    python run_optimization.py

--- a/doc/source/user_guide/installation_maxwell.rst
+++ b/doc/source/user_guide/installation_maxwell.rst
@@ -20,7 +20,7 @@ Create a ``profile.optimas`` file in your home directory with the following cont
     module load maxwell mamba
     . mamba-init
 
-you can do this from the command line by executing ``cat > profile.optimas`` and
+you can do this from the command line by executing ``cat > ~/profile.optimas`` and
 pasting the lines above. To save the file, finalize by pressing ``Ctrl+D``.
 
 Load the source file


### PR DESCRIPTION
Adds instructions for installing `optimas` on the JUWELS Booster, including how to get FBPIC and Wake-T in the same enviroment.

It also includes an example submission script.

When testing `optimas` on JUWELS, I noticed that things like the GPU assignment are not working as expected. This is partly on our side (we need to merge #88 first) and also what I think might be a bug in their system (I contacted support and will update this once I get a reply).

Update: It is a bug on JUWELS and they are working on it. Basically, when running with several workers and several GPUs per worker, the first worker gets only only GPU assigned (all ranks use GPU 0).