### PR TITLE
dedicated_resources for Generators: False by default

### DIFF
--- a/optimas/generators/ax/base.py
+++ b/optimas/generators/ax/base.py
@@ -27,7 +27,7 @@ class AxGenerator(Generator):
     dedicated_resources : bool, optional
         Whether to allocated dedicated resources (e.g., the GPU) for the
         generator. These resources will not be available to the
-        simulation workers. By default, ``True``.
+        simulation workers. By default, ``False``.
     save_model : bool, optional
         Whether to save the optimization model (e.g., the surrogate model) to
         disk. By default ``False``.
@@ -49,7 +49,7 @@ class AxGenerator(Generator):
         analyzed_parameters: Optional[List[Parameter]] = None,
         use_cuda: Optional[bool] = False,
         gpu_id: Optional[int] = 0,
-        dedicated_resources: Optional[bool] = True,
+        dedicated_resources: Optional[bool] = False,
         save_model: Optional[bool] = False,
         model_save_period: Optional[int] = 5,
         model_history_dir: Optional[str] = 'model_history',

--- a/optimas/generators/ax/developer/multitask.py
+++ b/optimas/generators/ax/developer/multitask.py
@@ -62,7 +62,7 @@ class AxMultitaskGenerator(AxGenerator):
     dedicated_resources : bool, optional
         Whether to allocated dedicated resources (e.g., the GPU) for the
         generator. These resources will not be available to the
-        simulation workers. By default, ``True``.
+        simulation workers. By default, ``False``.
     save_model : bool, optional
         Whether to save the optimization model (in this case, the Ax
         experiment) to disk. By default ``True``.
@@ -82,7 +82,7 @@ class AxMultitaskGenerator(AxGenerator):
         analyzed_parameters: Optional[List[Parameter]] = None,
         use_cuda: Optional[bool] = False,
         gpu_id: Optional[int] = 0,
-        dedicated_resources: Optional[bool] = True,
+        dedicated_resources: Optional[bool] = False,
         save_model: Optional[bool] = True,
         model_save_period: Optional[int] = 5,
         model_history_dir: Optional[str] = 'model_history'

--- a/optimas/generators/ax/service/base.py
+++ b/optimas/generators/ax/service/base.py
@@ -33,7 +33,7 @@ class AxServiceGenerator(AxGenerator):
     dedicated_resources : bool, optional
         Whether to allocated dedicated resources (e.g., the GPU) for the
         generator. These resources will not be available to the
-        simulation workers. By default, ``True``.
+        simulation workers. By default, ``False``.
     save_model : bool, optional
         Whether to save the optimization model (in this case, the Ax client) to
         disk. By default ``True``.
@@ -52,7 +52,7 @@ class AxServiceGenerator(AxGenerator):
         n_init: Optional[int] = 4,
         use_cuda: Optional[bool] = False,
         gpu_id: Optional[int] = 0,
-        dedicated_resources: Optional[bool] = True,
+        dedicated_resources: Optional[bool] = False,
         save_model: Optional[bool] = True,
         model_save_period: Optional[int] = 5,
         model_history_dir: Optional[str] = 'model_history',

--- a/optimas/generators/ax/service/multi_fidelity.py
+++ b/optimas/generators/ax/service/multi_fidelity.py
@@ -41,7 +41,7 @@ class AxMultiFidelityGenerator(AxServiceGenerator):
     dedicated_resources : bool, optional
         Whether to allocated dedicated resources (e.g., the GPU) for the
         generator. These resources will not be available to the
-        simulation workers. By default, ``True``.
+        simulation workers. By default, ``False``.
     save_model : bool, optional
         Whether to save the optimization model (in this case, the Ax client) to
         disk. By default ``True``.
@@ -61,7 +61,7 @@ class AxMultiFidelityGenerator(AxServiceGenerator):
         fidel_cost_intercept: Optional[float] = 1.,
         use_cuda: Optional[bool] = False,
         gpu_id: Optional[int] = 0,
-        dedicated_resources: Optional[bool] = True,
+        dedicated_resources: Optional[bool] = False,
         save_model: Optional[bool] = True,
         model_save_period: Optional[int] = 5,
         model_history_dir: Optional[str] = 'model_history',

--- a/optimas/generators/ax/service/single_fidelity.py
+++ b/optimas/generators/ax/service/single_fidelity.py
@@ -37,7 +37,7 @@ class AxSingleFidelityGenerator(AxServiceGenerator):
     dedicated_resources : bool, optional
         Whether to allocated dedicated resources (e.g., the GPU) for the
         generator. These resources will not be available to the
-        simulation workers. By default, ``True``.
+        simulation workers. By default, ``False``.
     save_model : bool, optional
         Whether to save the optimization model (in this case, the Ax client) to
         disk. By default ``True``.
@@ -56,7 +56,7 @@ class AxSingleFidelityGenerator(AxServiceGenerator):
         n_init: Optional[int] = 4,
         use_cuda: Optional[bool] = False,
         gpu_id: Optional[int] = 0,
-        dedicated_resources: Optional[bool] = True,
+        dedicated_resources: Optional[bool] = False,
         save_model: Optional[bool] = True,
         model_save_period: Optional[int] = 5,
         model_history_dir: Optional[str] = 'model_history',

--- a/optimas/generators/base.py
+++ b/optimas/generators/base.py
@@ -36,7 +36,7 @@ class Generator():
     dedicated_resources : bool, optional
         Whether to allocated dedicated resources (e.g., the GPU) for the
         generator. These resources will not be available to the
-        simulation workers. By default, ``True``.
+        simulation workers. By default, ``False``.
     save_model : bool, optional
         Whether to save the optimization model (e.g., the surrogate model) to
         disk. By default ``False``.
@@ -59,7 +59,7 @@ class Generator():
         analyzed_parameters: Optional[List[Parameter]] = None,
         use_cuda: Optional[bool] = False,
         gpu_id: Optional[int] = 0,
-        dedicated_resources: Optional[bool] = True,
+        dedicated_resources: Optional[bool] = False,
         save_model: Optional[bool] = False,
         model_save_period: Optional[int] = 5,
         model_history_dir: Optional[str] = 'model_history',


### PR DESCRIPTION
This avoids having the generators taking resources by default, which is often not desirable, esp. for simple generators such as the random generator, etc.