### PR TITLE
Run tests daily and with all supported python versions

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -3,7 +3,7 @@ name: Unix
 on:
   push:
   pull_request:
-  # Run daily at midnight.
+  # Run daily at midnight (UTC).
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -1,6 +1,11 @@
 name: Unix
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  # Run daily at midnight.
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   test:

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.8, 3.9, '3.10', 3.11]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR makes sure that the tests pass in all currently supported python versions (3.8 - 3.11). Also, since some dependencies like Ax seem to sometimes have breaking changes, the tests will now run daily to make sure we catch any issues with new releases of dependencies.