### PR TITLE
Allow resuming an exploration and running in substeps

### DIFF
--- a/optimas/explorations/base.py
+++ b/optimas/explorations/base.py
@@ -250,7 +250,7 @@ class Exploration():
         old_libe_history_files = glob.glob(
             os.path.join(
                 os.path.abspath(self.exploration_dir_path),
-                'libE_history_'.format("*")
+                'libE_history_{}'.format("*")
             )
         )
         old_files = old_exploration_history_files + old_libe_history_files

--- a/optimas/explorations/base.py
+++ b/optimas/explorations/base.py
@@ -125,7 +125,8 @@ class Exploration():
 
         # Get gen_specs and sim_specs.
         run_params = self.evaluator.get_run_params()
-        gen_specs = self.generator.get_gen_specs(self.sim_workers, run_params)
+        gen_specs = self.generator.get_gen_specs(self.sim_workers, run_params,
+                                                 sim_max)
         sim_specs = self.evaluator.get_sim_specs(
             self.generator.varying_parameters,
             self.generator.objectives,

--- a/optimas/explorations/base.py
+++ b/optimas/explorations/base.py
@@ -76,6 +76,7 @@ class Exploration():
             self.history_save_period = history_save_period
         self.exploration_dir_path = exploration_dir_path
         self.libe_comms = libe_comms
+        self._n_evals = 0
         self._load_history(history)
         self._create_alloc_specs()
         self._create_executor()
@@ -86,6 +87,9 @@ class Exploration():
         """Run the exploration."""
         # Set exit criteria to maximum number of evaluations.
         exit_criteria = {'sim_max': self.max_evals}
+
+        # Get initial number of generator trials.
+        n_trials_initial = self.generator.n_trials
 
         # Create persis_info.
         persis_info = add_unique_random_streams({}, self.sim_workers + 2)
@@ -122,6 +126,10 @@ class Exploration():
 
         # Update generator with the one received from libE.
         self.generator._update(persis_info[1]['generator'])
+
+        # Update number of evaluation in this exploration.
+        n_trials_final = self.generator.n_trials
+        self._n_evals += n_trials_final - n_trials_initial
 
         # Determine if current rank is master.
         if self.libE_specs["comms"] == "local":

--- a/optimas/explorations/base.py
+++ b/optimas/explorations/base.py
@@ -169,9 +169,6 @@ class Exploration():
                 history, persis_info, __file__, nworkers,
                 dest_path=os.path.abspath(self.exploration_dir_path))
 
-        # Reset state of libEnsemble.
-        self._reset_libensemble()
-
     def _create_executor(self) -> None:
         """Create libEnsemble executor."""
         self.executor = MPIExecutor()
@@ -253,19 +250,3 @@ class Exploration():
                 'async_return': self.run_async
             }
         }
-
-    def _reset_libensemble(self) -> None:
-        """Reset the state of libEnsemble.
-
-        After calling `libE`, some libEnsemble attributes do not come back to
-        their original states. This leads to issues if another `Exploration`
-        run is launched within the same script. This method resets the
-        necessary libEnsemble attributes to their original state.
-        """
-        if Resources.resources is not None:
-            del Resources.resources
-            Resources.resources = None
-        if Executor.executor is not None:
-            del Executor.executor
-            Executor.executor = None
-        LogConfig.config.logger_set = False

--- a/optimas/explorations/base.py
+++ b/optimas/explorations/base.py
@@ -236,6 +236,9 @@ class Exploration():
         libE_specs['use_workflow_dir'] = True
         libE_specs['workflow_dir_path'] = self.exploration_dir_path
 
+        # Ensure evaluations of last batch are sent back to the generator.
+        libE_specs["final_gen_send"] = True
+
         # get specs from generator and evaluator
         gen_libE_specs = self.generator.get_libe_specs()
         ev_libE_specs = self.evaluator.get_libe_specs()

--- a/optimas/explorations/base.py
+++ b/optimas/explorations/base.py
@@ -9,9 +9,6 @@ from libensemble.libE import libE
 from libensemble.tools import save_libE_output, add_unique_random_streams
 from libensemble.alloc_funcs.start_only_persistent import only_persistent_gens
 from libensemble.executors.mpi_executor import MPIExecutor
-from libensemble.resources.resources import Resources
-from libensemble.executors.executor import Executor
-from libensemble.logger import LogConfig
 
 from optimas.generators.base import Generator
 from optimas.evaluators.base import Evaluator
@@ -88,7 +85,7 @@ class Exploration():
         n_evals: Optional[int] = None
     ) -> None:
         """Run the exploration.
-        
+
         Parameters
         ----------
         n_evals : int, optional

--- a/optimas/gen_functions.py
+++ b/optimas/gen_functions.py
@@ -38,7 +38,7 @@ def persistent_generator(H, persis_info, gen_specs, libE_info):
 
     ps = PersistentSupport(libE_info, EVAL_GEN_TAG)
 
-    # Maximum number of total evaluations to generate.    
+    # Maximum number of total evaluations to generate.
     max_evals = gen_specs['user']['max_evals']
 
     # Number of points to generate initially.

--- a/optimas/generators/ax/developer/multitask.py
+++ b/optimas/generators/ax/developer/multitask.py
@@ -128,11 +128,12 @@ class AxMultitaskGenerator(AxGenerator):
     def get_gen_specs(
         self,
         sim_workers: int,
-        run_params: dict
+        run_params: Dict,
+        sim_max: int
     ) -> Dict:
         """Get the libEnsemble gen_specs."""
         # Get base specs.
-        gen_specs = super().get_gen_specs(sim_workers, run_params)
+        gen_specs = super().get_gen_specs(sim_workers, run_params, sim_max)
         # Add task to output parameters.
         max_length = max([len(self.lofi_task.name), len(self.hifi_task.name)])
         gen_specs['out'].append(('task', str, max_length))

--- a/optimas/generators/base.py
+++ b/optimas/generators/base.py
@@ -115,6 +115,10 @@ class Generator():
     @property
     def dedicated_resources(self):
         return self._dedicated_resources
+    
+    @property
+    def n_trials(self):
+        return len(self._trials)
 
     def ask(
         self,

--- a/optimas/generators/base.py
+++ b/optimas/generators/base.py
@@ -115,7 +115,7 @@ class Generator():
     @property
     def dedicated_resources(self):
         return self._dedicated_resources
-    
+
     @property
     def n_trials(self):
         return len(self._trials)

--- a/optimas/generators/base.py
+++ b/optimas/generators/base.py
@@ -248,7 +248,8 @@ class Generator():
     def get_gen_specs(
         self,
         sim_workers: int,
-        run_params: dict
+        run_params: Dict,
+        max_evals: int
     ) -> Dict:
         """Get the libEnsemble gen_specs.
 
@@ -256,6 +257,11 @@ class Generator():
         ----------
         sim_workers : int
             Total number of parallel simulation workers.
+        run_params : dict
+            Dictionary containing the number of processes and gpus
+            required.
+        max_evals : int
+            Maximum number of evaluations to generate.
         """
         self._prepare_to_send()
         gen_specs = {
@@ -285,7 +291,9 @@ class Generator():
                 # GPU in which to run generator.
                 'gpu_id': self._gpu_id,
                 # num of procs and gpus required
-                'run_params': run_params
+                'run_params': run_params,
+                # Maximum number of evaluations to generate.
+                'max_evals': max_evals
             }
         }
         return gen_specs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
 ]
 dependencies = [
-    'libensemble @ git+https://github.com/Libensemble/libensemble@develop',
+    'libensemble >= 1.0.0',
     'jinja2',
     'ax-platform >= 0.2.9',
     'mpi4py',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
 ]
 dependencies = [
-    'libensemble >= 0.10.2',
+    'libensemble @ git+https://github.com/Libensemble/libensemble@develop',
     'jinja2',
     'ax-platform >= 0.2.9',
     'mpi4py',

--- a/tests/test_exploration_resume.py
+++ b/tests/test_exploration_resume.py
@@ -1,0 +1,110 @@
+import os
+
+from optimas.explorations import Exploration
+from optimas.generators import RandomSamplingGenerator
+from optimas.evaluators import TemplateEvaluator
+from optimas.core import VaryingParameter, Objective
+
+
+def analysis_func(sim_dir, output_params):
+    """Analysis function used by the template evaluator."""
+    # Read back result from file
+    with open('result.txt') as f:
+        result = float(f.read())
+    output_params['f'] = result
+
+
+def test_exploration_in_steps():
+    """Test that an exploration runs correctly when doing so in several steps.
+    """
+    # Define variables and objectives.
+    var1 = VaryingParameter('x0', -50., 5.)
+    var2 = VaryingParameter('x1', -5., 15.)
+    obj = Objective('f', minimize=False)
+
+    # Define variables and objectives.
+    gen = RandomSamplingGenerator(
+        varying_parameters=[var1, var2],
+        objectives=[obj]
+    )
+
+    # Create template evaluator.
+    ev = TemplateEvaluator(
+        sim_template=os.path.join(
+            os.path.abspath(os.path.dirname(__file__)),
+            'resources',
+            'template_simulation_script.py'
+        ),
+        analysis_func=analysis_func
+    )
+
+    # Create exploration.
+    exploration = Exploration(
+        generator=gen,
+        evaluator=ev,
+        max_evals=30,
+        sim_workers=2,
+        exploration_dir_path='./tests_output/test_template_evaluator'
+    )
+
+    # Run exploration in several steps.
+    exploration.run(3)
+    exploration.run(4)
+    exploration.run(10)
+    exploration.run(5)
+    exploration.run()
+
+    # Check final state.
+    assert exploration._n_evals == len(exploration.history)
+    assert exploration._n_evals == gen.n_trials
+    assert exploration._n_evals == exploration.max_evals
+    assert exploration.history['gen_informed'][-1]
+
+
+def test_exploration_resume():
+    """Test that an exploration correctly resumes from a previous run.
+    """
+    # Define variables and objectives.
+    var1 = VaryingParameter('x0', -50., 5.)
+    var2 = VaryingParameter('x1', -5., 15.)
+    obj = Objective('f', minimize=False)
+
+    # Define variables and objectives.
+    gen = RandomSamplingGenerator(
+        varying_parameters=[var1, var2],
+        objectives=[obj]
+    )
+
+    # Create template evaluator.
+    ev = TemplateEvaluator(
+        sim_template=os.path.join(
+            os.path.abspath(os.path.dirname(__file__)),
+            'resources',
+            'template_simulation_script.py'
+        ),
+        analysis_func=analysis_func
+    )
+
+    # Create exploration.
+    exploration = Exploration(
+        generator=gen,
+        evaluator=ev,
+        max_evals=40,
+        sim_workers=2,
+        exploration_dir_path='./tests_output/test_template_evaluator',
+        resume=True
+    )
+
+    # Run exploration.
+    exploration.run()
+
+    # Check final state.
+    assert exploration._n_evals == len(exploration.history)
+    assert exploration._n_evals == gen.n_trials
+    assert exploration._n_evals == exploration.max_evals
+    assert exploration.history['gen_informed'][-1]
+
+
+if __name__ == '__main__':
+    test_exploration_in_steps()
+    test_exploration_resume()


### PR DESCRIPTION
This PR enables two new workflows addressing  #107:

1. Running an exploration in substeps:

```python
# Create exploration.
exploration = Exploration(
    generator=gen,
    evaluator=ev,
    max_evals=30,
    sim_workers=2
)

# Run exploration in several steps until reaching 30 evaluations.
exploration.run(n_evals=3)
exploration.run(n_evals=4)
exploration.run(n_evals=10)
exploration.run(n_evals=5)
exploration.run()  # Run remaining evaluations.
```
This can be useful when running `optimas` interactively. It would allow the user, for example, to tune the hyperparameters of the generator between each `run`.

2. Resuming from a previous exploration that was executed in the same `exploration_dir_path`.

```python
# Create exploration.
exploration = Exploration(
    generator=gen,
    evaluator=ev,
    max_evals=40,
    sim_workers=2,
    resume=True
)

# Run exploration until the total number of evaluations
# (including those of the previous run) reaches 40.
exploration.run()
```

This allows us to seamlessly continue a previous exploration

This features are enabled by the new `'reuse_output_dir'` and `'final_gen_send'` options in `libensemble` `v1.0.0`.

# Changes
- Added new `n_evals` argument to `Exploration.run`.
- Added new `resume` option to `Exploration`.
- The `Exploration` now keeps track of the number of evaluations.
- The history file that is saved after `run` finishes is now called `exploration_history_after_evaluation_{}.npy`.
- Added `n_trials` property to `Generator` to easily count how many trials it has generated.
- The final batch of evaluations is now also given back to the `Generator`. Previously the generator was not informed about them. As a consequence, the last generated trials in the `Ax` generators remained as not completed, even though they did run.
- A bug has been fixed in the `gen_function` where more trials than needed would be generated in the final batch. The `gen_function` is now aware of the maximum number of trials that should be generated.
- The `Exploration._reset_libensemble` method has been removed. It seems that this workaround (introduced in #88) is no longer needed in `libensemble` `v1.0.0`.
- Update requirements to `libensemble` `v1.0.0`.
- Added new tests for both workflows.
