### PR TITLE
Disable Ax logs

### DIFF
--- a/optimas/generators/ax/base.py
+++ b/optimas/generators/ax/base.py
@@ -3,7 +3,6 @@ from typing import List, Optional
 import logging
 
 import torch
-from ax.utils.common.logger import get_logger
 
 from optimas.core import Objective, TrialParameter, VaryingParameter, Parameter
 from optimas.generators.base import Generator
@@ -12,13 +11,9 @@ from optimas.generators.base import Generator
 # Disable Ax loggers to get cleaner output. In principle, setting
 # `verbose_logging=False` in the `AxClient` should already avoid most of the
 # logs, but this does not work when using 'spawn' multiprocessing.
-for name in [
-    "ax.service.ax_client",
-    "ax.service.utils.instantiation",
-    "ax.modelbridge.torch",
-    "ax.core.experiment"
-]:
-    get_logger(name, level=logging.ERROR)
+for logger in logging.root.manager.loggerDict:
+    if logger.startswith("ax.") or logger == "ax":
+        logging.getLogger(logger).setLevel(logging.ERROR)
 
 
 class AxGenerator(Generator):

--- a/optimas/generators/ax/base.py
+++ b/optimas/generators/ax/base.py
@@ -13,9 +13,9 @@ from optimas.generators.base import Generator
 # `verbose_logging=False` in the `AxClient` should already avoid most of the
 # logs, but this does not work when using 'spawn' multiprocessing.
 for name in [
-    'ax.service.ax_client',
-    'ax.service.utils.instantiation',
-    'ax.modelbridge.torch'
+    "ax.service.ax_client",
+    "ax.service.utils.instantiation",
+    "ax.modelbridge.torch",
 ]:
     get_logger(name, level=logging.ERROR)
 

--- a/optimas/generators/ax/base.py
+++ b/optimas/generators/ax/base.py
@@ -16,6 +16,7 @@ for name in [
     "ax.service.ax_client",
     "ax.service.utils.instantiation",
     "ax.modelbridge.torch",
+    "ax.core.experiment"
 ]:
     get_logger(name, level=logging.ERROR)
 

--- a/optimas/generators/ax/base.py
+++ b/optimas/generators/ax/base.py
@@ -1,10 +1,23 @@
 """Contains the definition of the base Ax generator."""
 from typing import List, Optional
+import logging
 
 import torch
+from ax.utils.common.logger import get_logger
 
 from optimas.core import Objective, TrialParameter, VaryingParameter, Parameter
 from optimas.generators.base import Generator
+
+
+# Disable Ax loggers to get cleaner output. In principle, setting
+# `verbose_logging=False` in the `AxClient` should already avoid most of the
+# logs, but this does not work when using 'spawn' multiprocessing.
+for name in [
+    'ax.service.ax_client',
+    'ax.service.utils.instantiation',
+    'ax.modelbridge.torch'
+]:
+    get_logger(name, level=logging.ERROR)
 
 
 class AxGenerator(Generator):


### PR DESCRIPTION
Fixes a bug where the Ax logs were still being displayed even if `verbose_logging=False` was given to the `AxClient`. This was only happening when using `spawn` multiprocessing (the default on Windows and Mac).

The logs are mostly a duplicate of the optimas logs, so disabling them keeps the output cleaner.