### PR TITLE
Avoid pydata theme warning

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -89,6 +89,7 @@ html_theme_options = {
     "pygment_dark_style": "monokai",
     "use_edit_page_button": True,
     "navigation_depth": 2,
+    "navigation_with_keys": False
 }
 
 html_context = {

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -89,7 +89,7 @@ html_theme_options = {
     "pygment_dark_style": "monokai",
     "use_edit_page_button": True,
     "navigation_depth": 2,
-    "navigation_with_keys": False
+    "navigation_with_keys": False,
 }
 
 html_context = {


### PR DESCRIPTION
The latest version of the theme raises a warning if `navigation_with_keys` is not explicitly set, which causes readthedocs to report a failed build. This PR simply sets it to the new default.