### PR TITLE
Run generator in serial on manager

### DIFF
--- a/optimas/explorations/base.py
+++ b/optimas/explorations/base.py
@@ -138,8 +138,6 @@ class Exploration:
         if self.generator.dedicated_resources and self.generator.use_cuda:
             persis_info["gen_resources"] = 1
             persis_info["gen_use_gpus"] = True
-        else:
-            self.libE_specs["zero_resource_workers"] = [1]
 
         if self._n_evals > 0:
             self.libE_specs["reuse_output_dir"] = True

--- a/optimas/explorations/base.py
+++ b/optimas/explorations/base.py
@@ -8,7 +8,9 @@ import numpy as np
 
 from libensemble.libE import libE
 from libensemble.tools import add_unique_random_streams
-from libensemble.alloc_funcs.start_only_persistent import only_persistent_gens
+
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
+
 from libensemble.executors.mpi_executor import MPIExecutor
 
 from optimas.generators.base import Generator
@@ -168,7 +170,7 @@ class Exploration:
         self.history = history
 
         # Update generator with the one received from libE.
-        self.generator._update(persis_info[1]["generator"])
+        # self.generator._update(persis_info[1]["generator"])
 
         # Update number of evaluation in this exploration.
         n_trials_final = self.generator.n_trials
@@ -304,6 +306,7 @@ class Exploration:
         libE_specs["ensemble_dir_path"] = "evaluations"
         libE_specs["use_workflow_dir"] = True
         libE_specs["workflow_dir_path"] = self.exploration_dir_path
+        libE_specs["gen_on_manager"] = True
 
         # Ensure evaluations of last batch are sent back to the generator.
         libE_specs["final_gen_send"] = True
@@ -316,7 +319,6 @@ class Exploration:
     def _create_alloc_specs(self) -> None:
         """Create exploration alloc_specs."""
         self.alloc_specs = {
-            "alloc_f": only_persistent_gens,
-            "out": [("given_back", bool)],
-            "user": {"async_return": self.run_async},
+            "alloc_f": give_sim_work_first,
+            "user": {"batch_mode": not self.run_async, "num_activate_gens": 1},
         }

--- a/optimas/gen_classes.py
+++ b/optimas/gen_classes.py
@@ -1,5 +1,4 @@
-# SH whether to have a base class
-
+"""Contains the definition of the generator classes given to libEnsemble."""
 import os
 import numpy as np
 
@@ -7,7 +6,10 @@ from optimas.core import Evaluation
 from libensemble.resources.resources import Resources
 
 
+# SH whether to have a base class - could also support wrapper.
 class Optgen:
+    """A generator class for libEnsemble."""
+
     # SH TODO What args needed for init
     # def __init__(self, persis_info, gen_specs, libE_info):
     def __init__(self, gen_specs):
@@ -55,7 +57,6 @@ class Optgen:
 
         Pass the class as gen_f instead of a function
         """
-
         # SH note - not yet giving manager resources.
 
         if H is not None and H.size > 0:
@@ -115,5 +116,6 @@ class Optgen:
 
     # If finalize function exists, called at end
     def finalize(self, H, persis_info, gen_specs, libE_info):
+        """Receives any points generator has not seen and optionally updates history/persis_info."""
         print(f"Finalize received: {H=}")  # SH testing
         # return H_o, persis_info

--- a/optimas/gen_classes.py
+++ b/optimas/gen_classes.py
@@ -1,0 +1,118 @@
+# SH whether to have a base class
+
+import os
+import numpy as np
+
+from optimas.core import Evaluation
+from libensemble.resources.resources import Resources
+
+
+class Optgen:
+    # SH TODO What args needed for init
+    # def __init__(self, persis_info, gen_specs, libE_info):
+    def __init__(self, gen_specs):
+        # If CUDA is available, run BO loop on the GPU.
+        if gen_specs["user"]["use_cuda"]:
+            resources = Resources.resources.worker_resources
+            # If there is no dedicated slot for the generator, use the GPU
+            # specified by the user. This GPU will be shared with the
+            # simulation workers.
+            if resources.slot_count is None:
+                gpu_id = str(gen_specs["user"]["gpu_id"])
+                os.environ["CUDA_VISIBLE_DEVICES"] = gpu_id
+            # If there is a dedicated slot for the generator, use the
+            # corresponding GPU. This GPU will only be used for the generator
+            # and will not be available for the simulation workers.
+            else:
+                resources.set_env_to_gpus("CUDA_VISIBLE_DEVICES")
+
+        # Get generator, objectives, and parameters to analyze.
+        self.generator = gen_specs["user"]["generator"]
+        self.objectives = self.generator.objectives
+        self.analyzed_parameters = self.generator.analyzed_parameters
+
+        # Maximum number of total evaluations to generate.
+        self.max_evals = gen_specs["user"]["max_evals"]
+
+        # Number of points to generate initially.
+        self.number_of_gen_points = min(
+            gen_specs["user"]["gen_batch_size"], self.max_evals
+        )
+
+        self.n_gens = 0
+        self.n_failed_gens = 0
+
+    def run(self, H, persis_info, gen_specs, libE_info):
+        """Generate and launch evaluations with the optimas generators.
+
+        This function gets the generator object and uses it to generate new
+        evaluations via the `ask` method. Once finished, the result of the
+        evaluations is communicated back to the generator via the `tell`
+        method.
+
+        This function can be processed by the manager with
+        libE_specs["gen_on_manager"] = True
+
+        Pass the class as gen_f instead of a function
+        """
+
+        # SH note - not yet giving manager resources.
+
+        if H is not None and H.size > 0:
+            # Check how many simulations have returned
+            n = len(H["sim_id"])
+            # Update the GP with latest simulation results
+            for i in range(n):
+                trial_index = int(H["trial_index"][i])
+                trial = self.generator._trials[trial_index]
+                for par in self.objectives + self.analyzed_parameters:
+                    y = H[par.name][i]
+                    ev = Evaluation(parameter=par, value=y)
+                    trial.complete_evaluation(ev)
+                # Register trial with unknown SEM
+                self.generator.tell([trial])
+            # Set the number of points to generate to that number:
+            self.number_of_gen_points = min(
+                n + self.n_failed_gens, self.max_evals - self.n_gens
+            )
+            self.n_failed_gens = 0
+
+        # Ask the optimizer to generate `batch_size` new points
+        H_o = np.zeros(self.number_of_gen_points, dtype=gen_specs["out"])
+        for i in range(self.number_of_gen_points):
+            generated_trials = self.generator.ask(1)
+            if generated_trials:
+                trial = generated_trials[0]
+                for var, val in zip(
+                    trial.varying_parameters, trial.parameter_values
+                ):
+                    H_o[var.name][i] = val
+                run_params = gen_specs["user"]["run_params"]
+                if "task" in H_o.dtype.names:
+                    H_o["task"][i] = trial.trial_type
+                    run_params = run_params[trial.trial_type]
+                if trial.custom_parameters is not None:
+                    for par in trial.custom_parameters:
+                        H_o[par.save_name][i] = getattr(trial, par.name)
+                H_o["trial_index"][i] = trial.index
+                H_o["num_procs"][i] = run_params["num_procs"]
+                H_o["num_gpus"][i] = run_params["num_gpus"]
+
+        self.n_gens += np.sum(H_o["num_procs"] != 0)
+        self.n_failed_gens = np.sum(H_o["num_procs"] == 0)
+        H_o = H_o[H_o["num_procs"] > 0]
+
+        # Add updated generator to `persis_info`.
+        # self.generator._prepare_to_send()  # If need, should be in finalize
+        # persis_info["generator"] = generator  #not required
+
+        # Do we want to share these via persis_info?
+        # persis_info["n_gens"] = self.n_gens
+        # persis_info["n_failed_gens"] = self.n_failed_gens
+
+        # should not need to return persis_info - update in place
+        return H_o, persis_info
+
+    # SH if this exists could be used like final_gen_send
+    def finalize(self, H, persis_info, gen_specs, libE_info):
+        pass

--- a/optimas/gen_classes.py
+++ b/optimas/gen_classes.py
@@ -113,6 +113,7 @@ class Optgen:
         # should not need to return persis_info - update in place
         return H_o, persis_info
 
-    # SH if this exists could be used like final_gen_send
+    # If finalize function exists, called at end
     def finalize(self, H, persis_info, gen_specs, libE_info):
-        pass
+        print(f"Finalize received: {H=}")  # SH testing
+        # return H_o, persis_info

--- a/optimas/gen_functions.py
+++ b/optimas/gen_functions.py
@@ -129,7 +129,6 @@ def non_persistent_generator(H, persis_info, gen_specs, libE_info):
     This function can be processed by the manager with
     libE_specs["gen_on_manager"] = True
     """
-
     # SH note - not yet giving manager resources.
 
     # If CUDA is available, run BO loop on the GPU.

--- a/optimas/generators/base.py
+++ b/optimas/generators/base.py
@@ -8,7 +8,11 @@ import numpy as np
 
 from optimas.utils.logger import get_logger
 from optimas.utils.other import update_object
-from optimas.gen_functions import persistent_generator
+
+# from optimas.gen_functions import persistent_generator
+# from optimas.gen_functions import non_persistent_generator
+from optimas.gen_classes import Optgen
+
 from optimas.core import (
     Objective,
     Trial,
@@ -93,7 +97,10 @@ class Generator:
         self._custom_trial_parameters = (
             [] if custom_trial_parameters is None else custom_trial_parameters
         )
-        self._gen_function = persistent_generator
+        # self._gen_function = persistent_generator
+        # self._gen_function = non_persistent_generator
+        self._gen_function = Optgen  # class
+
         self._trials = []
 
     @property
@@ -281,8 +288,7 @@ class Generator:
             # Generator function.
             "gen_f": self._gen_function,
             # Generator input. This is a RNG, no need for inputs.
-            "in": ["sim_id"],
-            "persis_in": (
+            "in": (
                 ["sim_id", "trial_index"]
                 + [obj.name for obj in self._objectives]
                 + [par.name for par in self._analyzed_parameters]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
 ]
 dependencies = [
-    'libensemble >= 1.0.0',
+    'libensemble @ git+https://github.com/Libensemble/libensemble@experimental/gen_on_manager_inplace',
     'jinja2',
     'ax-platform >= 0.2.9',
     'mpi4py',

--- a/tests/test_exploration_resume.py
+++ b/tests/test_exploration_resume.py
@@ -56,6 +56,7 @@ def test_exploration_in_steps():
     assert exploration._n_evals == len(exploration.history)
     assert exploration._n_evals == gen.n_trials
     assert exploration._n_evals == exploration.max_evals
+    print(f"{exploration.history['gen_informed']=}")
     assert exploration.history["gen_informed"][-1]
 
 


### PR DESCRIPTION
This is proof-of-principle for running the generator in-place on the manager.

- The generator can be provided as a function or a class (see generators/base.py)
- Giving resources to the generator has not yet been implemented.
- Tested with test_ax_generators.py

This represents one possible approach (pros/cons)
- Allows pass by reference
- Reduces communications
- Easier to debug generator issues (compared to using a thread)
- Easy to support using a gen directory (compared to using a thread)
- Works naturally with a class generator.
- Use of finalize routine seems intuitive in place of final_gen_send.
- con: Requires moving from current persistent style generator
- con: Will block on long running gen.
