### PR TITLE
Use new libE save history options

### DIFF
--- a/optimas/explorations/base.py
+++ b/optimas/explorations/base.py
@@ -170,18 +170,6 @@ class Exploration:
         n_trials_final = self.generator.n_trials
         self._n_evals += n_trials_final - n_trials_initial
 
-        # Determine if current rank is master.
-        if self.libE_specs["comms"] == "local":
-            is_master = True
-        else:
-            from mpi4py import MPI
-
-            is_master = MPI.COMM_WORLD.Get_rank() == 0
-
-        # Save history.
-        if is_master:
-            self._save_history()
-
     def _create_executor(self) -> None:
         """Create libEnsemble executor."""
         self.executor = MPIExecutor()
@@ -231,19 +219,6 @@ class Exploration:
         if resume:
             self._n_evals = history.size
         self.history = history
-
-    def _save_history(self):
-        """Save history array to file."""
-        filename = self._history_file_name.format(self._n_evals)
-        exploration_dir_path = os.path.abspath(self.exploration_dir_path)
-        file_path = os.path.join(exploration_dir_path, filename)
-        if not os.path.isfile(filename):
-            old_files = os.path.join(
-                exploration_dir_path, self._history_file_name.format("*")
-            )
-            for old_file in glob.glob(old_files):
-                os.remove(old_file)
-            np.save(file_path, self.history)
 
     def _get_most_recent_history_file_path(self):
         """Get path of most recently saved history file."""

--- a/optimas/explorations/base.py
+++ b/optimas/explorations/base.py
@@ -304,6 +304,13 @@ class Exploration:
         # Ensure evaluations of last batch are sent back to the generator.
         libE_specs["final_gen_send"] = True
 
+        # Save history file on completion and without date information in the
+        # name, so that it can be overwritten in subsequent calls to `run` or
+        # when resuming an exploration.
+        libE_specs["save_H_on_completion"] = True
+        libE_specs["save_H_with_date"] = False
+        libE_specs["H_file_prefix"] = "exploration_history"
+
         # get specs from generator and evaluator
         gen_libE_specs = self.generator.get_libe_specs()
         ev_libE_specs = self.evaluator.get_libe_specs()

--- a/optimas/explorations/base.py
+++ b/optimas/explorations/base.py
@@ -229,8 +229,8 @@ class Exploration:
             os.path.join(exp_path, self._history_file_prefix + "*")
         )
         history_files.sort(
-                key=lambda f: os.path.getmtime(os.path.join(exp_path, f))
-            )
+            key=lambda f: os.path.getmtime(os.path.join(exp_path, f))
+        )
         if history_files:
             return history_files[-1]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
 ]
 dependencies = [
-    'libensemble >= 1.0.0',
+    'libensemble @ git+https://github.com/Libensemble/libensemble@develop',
     'jinja2',
     'ax-platform >= 0.2.9',
     'mpi4py',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
 ]
 dependencies = [
-    'libensemble @ git+https://github.com/Libensemble/libensemble@develop',
+    'libensemble >= 1.1.0',
     'jinja2',
     'ax-platform >= 0.2.9',
     'mpi4py',

--- a/tests/test_exploration_resume.py
+++ b/tests/test_exploration_resume.py
@@ -57,6 +57,7 @@ def test_exploration_in_steps():
     assert exploration._n_evals == gen.n_completed_trials
     assert exploration._n_evals == exploration.max_evals
     assert exploration.history["gen_informed"].to_numpy()[-1]
+    assert count_history_files(exploration.exploration_dir_path) == 1
 
 
 def test_exploration_in_steps_without_limit():
@@ -144,6 +145,19 @@ def test_exploration_resume():
     assert exploration._n_evals == gen.n_completed_trials
     assert exploration._n_evals == exploration.max_evals
     assert exploration.history["gen_informed"].to_numpy()[-1]
+    assert count_history_files(exploration.exploration_dir_path) == 1
+
+
+def count_history_files(exploration_dir):
+    """"Count the number of history files in a directory."""
+    files = os.listdir(exploration_dir)
+    count = 0
+    for file in files:
+        file = str(file)
+        if file.endswith(".npy") and "_history_" in file:
+            count += 1
+    return count
+
 
 
 if __name__ == "__main__":

--- a/tests/test_exploration_resume.py
+++ b/tests/test_exploration_resume.py
@@ -149,7 +149,7 @@ def test_exploration_resume():
 
 
 def count_history_files(exploration_dir):
-    """"Count the number of history files in a directory."""
+    """ "Count the number of history files in a directory."""
     files = os.listdir(exploration_dir)
     count = 0
     for file in files:
@@ -157,7 +157,6 @@ def count_history_files(exploration_dir):
         if file.endswith(".npy") and "_history_" in file:
             count += 1
     return count
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Use the new `libE_specs` options `"save_H_on_completion"`, `"save_H_with_date"` and `"H_file_prefix"` to customize the name of the history file and make sure that there is only one file per exploration.