### PR TITLE
Reduce number of initialization evaluations if external data is supplied

### DIFF
--- a/optimas/generators/ax/service/ax_client.py
+++ b/optimas/generators/ax/service/ax_client.py
@@ -75,6 +75,7 @@ class AxClientGenerator(AxServiceGenerator):
             varying_parameters=varying_parameters,
             objectives=objectives,
             analyzed_parameters=analyzed_parameters,
+            enforce_n_init=True,
             use_cuda=use_cuda,
             gpu_id=gpu_id,
             dedicated_resources=dedicated_resources,

--- a/optimas/generators/ax/service/base.py
+++ b/optimas/generators/ax/service/base.py
@@ -108,7 +108,7 @@ class AxServiceGenerator(AxGenerator):
                 # Since data was given externally, reduce number of
                 # initialization trials.
                 gs = self._ax_client.generation_strategy
-                if isinstance(gs.current_step.model, Models.SOBOL):
+                if gs.current_step.model == Models.SOBOL:
                     ngen, _ = gs._num_trials_to_gen_and_complete_in_curr_step()
                     if ngen > 0:
                         gs.current_step.num_trials -= 1

--- a/optimas/generators/ax/service/base.py
+++ b/optimas/generators/ax/service/base.py
@@ -27,7 +27,12 @@ class AxServiceGenerator(AxGenerator):
         optimization objectives. By default ``None``.
     n_init : int, optional
         Number of evaluations to perform during the initialization phase using
-        Sobol sampling. By default, ``4``.
+        Sobol sampling. If external data is attached to the exploration, the
+        number of initialization evaluations will be reduced by the same
+        amount, unless `enforce_n_init=True`. By default, ``4``.
+    enforce_n_init : bool, optional
+        Whether to enforce the generation of `n_init` Sobol trials, even if
+        external data is supplied. By default, ``False``.
     use_cuda : bool, optional
         Whether to allow the generator to run on a CUDA GPU. By default
         ``False``.
@@ -55,6 +60,7 @@ class AxServiceGenerator(AxGenerator):
         objectives: List[Objective],
         analyzed_parameters: Optional[List[Parameter]] = None,
         n_init: Optional[int] = 4,
+        enforce_n_init: Optional[bool] = False,
         use_cuda: Optional[bool] = False,
         gpu_id: Optional[int] = 0,
         dedicated_resources: Optional[bool] = False,
@@ -74,6 +80,7 @@ class AxServiceGenerator(AxGenerator):
             model_history_dir=model_history_dir,
         )
         self._n_init = n_init
+        self._enforce_n_init = enforce_n_init
         self._ax_client = self._create_ax_client()
 
     def _ask(self, trials: List[Trial]) -> List[Trial]:
@@ -107,10 +114,10 @@ class AxServiceGenerator(AxGenerator):
 
                 # Since data was given externally, reduce number of
                 # initialization trials.
-                gs = self._ax_client.generation_strategy
-                if gs.current_step.model == Models.SOBOL:
+                if not self._enforce_n_init:
+                    gs = self._ax_client.generation_strategy
                     ngen, _ = gs._num_trials_to_gen_and_complete_in_curr_step()
-                    if ngen > 0:
+                    if gs.current_step.model == Models.SOBOL and ngen > 0:
                         gs.current_step.num_trials -= 1
 
     def _create_ax_client(self) -> AxClient:

--- a/optimas/generators/ax/service/base.py
+++ b/optimas/generators/ax/service/base.py
@@ -117,6 +117,7 @@ class AxServiceGenerator(AxGenerator):
                 if not self._enforce_n_init:
                     gs = self._ax_client.generation_strategy
                     ngen, _ = gs._num_trials_to_gen_and_complete_in_curr_step()
+                    # Reduce only if there are still Sobol trials to generate.
                     if gs.current_step.model == Models.SOBOL and ngen > 0:
                         gs.current_step.num_trials -= 1
 

--- a/optimas/generators/ax/service/multi_fidelity.py
+++ b/optimas/generators/ax/service/multi_fidelity.py
@@ -29,7 +29,12 @@ class AxMultiFidelityGenerator(AxServiceGenerator):
         optimization objectives. By default ``None``.
     n_init : int, optional
         Number of evaluations to perform during the initialization phase using
-        Sobol sampling. By default, ``4``.
+        Sobol sampling. If external data is attached to the exploration, the
+        number of initialization evaluations will be reduced by the same
+        amount, unless `enforce_n_init=True`. By default, ``4``.
+    enforce_n_init : bool, optional
+        Whether to enforce the generation of `n_init` Sobol trials, even if
+        external data is supplied. By default, ``False``.
     fidel_cost_intercept : float, optional
         The cost intercept for the affine cost of the form
         `cost_intercept + n`, where `n` is the number of generated points.
@@ -61,6 +66,7 @@ class AxMultiFidelityGenerator(AxServiceGenerator):
         objectives: List[Objective],
         analyzed_parameters: Optional[List[Parameter]] = None,
         n_init: Optional[int] = 4,
+        enforce_n_init: Optional[bool] = False,
         fidel_cost_intercept: Optional[float] = 1.0,
         use_cuda: Optional[bool] = False,
         gpu_id: Optional[int] = 0,
@@ -75,6 +81,7 @@ class AxMultiFidelityGenerator(AxServiceGenerator):
             objectives=objectives,
             analyzed_parameters=analyzed_parameters,
             n_init=n_init,
+            enforce_n_init=enforce_n_init,
             use_cuda=use_cuda,
             gpu_id=gpu_id,
             dedicated_resources=dedicated_resources,

--- a/optimas/generators/ax/service/single_fidelity.py
+++ b/optimas/generators/ax/service/single_fidelity.py
@@ -38,7 +38,12 @@ class AxSingleFidelityGenerator(AxServiceGenerator):
         optimization objectives. By default ``None``.
     n_init : int, optional
         Number of evaluations to perform during the initialization phase using
-        Sobol sampling. By default, ``4``.
+        Sobol sampling. If external data is attached to the exploration, the
+        number of initialization evaluations will be reduced by the same
+        amount, unless `enforce_n_init=True`. By default, ``4``.
+    enforce_n_init : bool, optional
+        Whether to enforce the generation of `n_init` Sobol trials, even if
+        external data is supplied. By default, ``False``.
     fully_bayesian : bool, optional
         Whether to optimize the hyperparameters of the GP with a fully
         Bayesian approach (using SAAS priors) instead of maximizing
@@ -81,6 +86,7 @@ class AxSingleFidelityGenerator(AxServiceGenerator):
         objectives: List[Objective],
         analyzed_parameters: Optional[List[Parameter]] = None,
         n_init: Optional[int] = 4,
+        enforce_n_init: Optional[bool] = False,
         fully_bayesian: Optional[bool] = False,
         use_cuda: Optional[bool] = False,
         gpu_id: Optional[int] = 0,
@@ -95,6 +101,7 @@ class AxSingleFidelityGenerator(AxServiceGenerator):
             objectives=objectives,
             analyzed_parameters=analyzed_parameters,
             n_init=n_init,
+            enforce_n_init=enforce_n_init,
             use_cuda=use_cuda,
             gpu_id=gpu_id,
             dedicated_resources=dedicated_resources,

--- a/tests/test_ax_generators.py
+++ b/tests/test_ax_generators.py
@@ -427,6 +427,93 @@ def test_ax_multitask_with_history():
     exploration.run()
 
 
+def test_ax_service_init():
+    """
+    Test that an exploration with using an AxServiceGenerator correctly
+    reduces the number of `n_init` SOBOL evaluations if external trials
+    or evaluations are given.
+    """
+
+    var1 = VaryingParameter("x0", -50.0, 5.0)
+    var2 = VaryingParameter("x1", -5.0, 15.0)
+    obj = Objective("f", minimize=False)
+
+    n_init = 4
+    n_external = 6
+    
+    for i in range(n_external):
+
+        gen = AxSingleFidelityGenerator(
+            varying_parameters=[var1, var2], objectives=[obj], n_init=n_init
+        )
+        ev = FunctionEvaluator(function=eval_func_sf)
+        exploration = Exploration(
+            generator=gen,
+            evaluator=ev,
+            max_evals=6,
+            sim_workers=2,
+            exploration_dir_path="./tests_output/test_ax_single_fidelity",
+        )
+
+        # Get reference to original AxClient.
+        ax_client = gen._ax_client
+
+        for _ in range(i):
+            exploration.evaluate_trials(
+                {
+                    "x0": [-2.0 + np.random.rand(1)[0]],
+                    "x1": [2.7 + np.random.rand(1)[0]],
+                }
+            )
+        # Run exploration.
+        exploration.run()
+
+        # Check that the number of SOBOL trials is reduced and that they
+        # are replaced by Manual trials.
+        df = ax_client.get_trials_data_frame()
+        for j in range(i):
+            assert df["generation_method"][j] == "Manual"
+        for k in range(i, n_init - 1):
+            assert df["generation_method"][k] == "Sobol"
+        df["generation_method"][min(i, n_init)] == "GPEI"
+
+
+    # Test single case with `enforce_n_init=True`
+    gen = AxSingleFidelityGenerator(
+        varying_parameters=[var1, var2], objectives=[obj], n_init=n_init, enforce_n_init=True
+    )
+    ev = FunctionEvaluator(function=eval_func_sf)
+    exploration = Exploration(
+        generator=gen,
+        evaluator=ev,
+        max_evals=15,
+        sim_workers=2,
+        exploration_dir_path="./tests_output/test_ax_service_init_enforce",
+    )
+
+    # Get reference to original AxClient.
+    ax_client = gen._ax_client
+
+    for _ in range(n_external):
+        exploration.evaluate_trials(
+            {
+                "x0": [-2.0 + np.random.rand(1)[0]],
+                "x1": [2.7 + np.random.rand(1)[0]],
+            }
+        )
+    # Run exploration.
+    exploration.run()
+
+    # Check that the number of SOBOL trials is reduced and that they
+    # are replaced by Manual trials.
+    df = ax_client.get_trials_data_frame()
+    for j in range(n_external):
+        assert df["generation_method"][j] == "Manual"
+    for k in range(n_external, n_external + n_init):
+        assert df["generation_method"][k] == "Sobol"
+    df["generation_method"][n_external + n_init] == "GPEI"
+
+
 if __name__ == "__main__":
     test_ax_single_fidelity()
     test_ax_single_fidelity_moo()
@@ -438,3 +525,4 @@ if __name__ == "__main__":
     test_ax_single_fidelity_with_history()
     test_ax_multi_fidelity_with_history()
     test_ax_multitask_with_history()
+    test_ax_service_init()

--- a/tests/test_ax_generators.py
+++ b/tests/test_ax_generators.py
@@ -454,7 +454,7 @@ def test_ax_service_init():
             exploration_dir_path="./tests_output/test_ax_single_fidelity",
         )
 
-        # Get reference to original AxClient.
+        # Get reference to AxClient.
         ax_client = gen._ax_client
 
         for _ in range(i):
@@ -492,7 +492,7 @@ def test_ax_service_init():
         exploration_dir_path="./tests_output/test_ax_service_init_enforce",
     )
 
-    # Get reference to original AxClient.
+    # Get reference to AxClient.
     ax_client = gen._ax_client
 
     for _ in range(n_external):
@@ -505,8 +505,8 @@ def test_ax_service_init():
     # Run exploration.
     exploration.run()
 
-    # Check that the number of SOBOL trials is reduced and that they
-    # are replaced by Manual trials.
+    # Check that the number of SOBOL trials is `still n_init` after adding
+    # `n_external` Manual trials.
     df = ax_client.get_trials_data_frame()
     for j in range(n_external):
         assert df["generation_method"][j] == "Manual"

--- a/tests/test_ax_generators.py
+++ b/tests/test_ax_generators.py
@@ -451,7 +451,7 @@ def test_ax_service_init():
             evaluator=ev,
             max_evals=6,
             sim_workers=2,
-            exploration_dir_path="./tests_output/test_ax_single_fidelity",
+            exploration_dir_path=f"./tests_output/test_ax_service_init_{i}",
         )
 
         # Get reference to AxClient.
@@ -505,7 +505,7 @@ def test_ax_service_init():
     # Run exploration.
     exploration.run()
 
-    # Check that the number of SOBOL trials is `still n_init` after adding
+    # Check that the number of SOBOL trials is still `n_init` after adding
     # `n_external` Manual trials.
     df = ax_client.get_trials_data_frame()
     for j in range(n_external):

--- a/tests/test_ax_generators.py
+++ b/tests/test_ax_generators.py
@@ -440,9 +440,8 @@ def test_ax_service_init():
 
     n_init = 4
     n_external = 6
-    
-    for i in range(n_external):
 
+    for i in range(n_external):
         gen = AxSingleFidelityGenerator(
             varying_parameters=[var1, var2], objectives=[obj], n_init=n_init
         )
@@ -477,10 +476,12 @@ def test_ax_service_init():
             assert df["generation_method"][k] == "Sobol"
         df["generation_method"][min(i, n_init)] == "GPEI"
 
-
     # Test single case with `enforce_n_init=True`
     gen = AxSingleFidelityGenerator(
-        varying_parameters=[var1, var2], objectives=[obj], n_init=n_init, enforce_n_init=True
+        varying_parameters=[var1, var2],
+        objectives=[obj],
+        n_init=n_init,
+        enforce_n_init=True,
     )
     ev = FunctionEvaluator(function=eval_func_sf)
     exploration = Exploration(


### PR DESCRIPTION
Currently, it is not possible to skip the initialization step of the Ax generators. This is not convenient, because it means that the first trials suggested by the generator will always be quasi-random, even if the user supplied external data to initialize the model. This PR fixes this issue by reducing the number of Sobol trials if external data is provided by the user.

There were several options to implement this:
1. **Allow the user to set `n_init=0`**: In this case, we would simply not add a Sobol step to the AxClient. However, this is not safe in all cases, because the BO step requires some initial data to be able to start. Also, it you want to resume a previous exploration, you would need to change the input script to set `n_init=0` to avoid rerunning the Sobol step.
2. **Do not add a Sobol generation step if external data is given**: Currently not possible, because the AxClient is initialized when creating the generator, and this is done before the exploration object exists. Therefore, the generator cannot know in advance whether external data will be loaded. This could of course be reimplemented so that the AxClient is only initialized once the Exploration starts, but this would break a current workflow in which we allow the user to access the AxClient of the generator.
3. **Always have a Sobol step with `n_init>0`, and only reduce the number of Sobol trials once external data is given**: This solves the issue with option 1. If a user resumes an exploration by running the same original script, the optimization will continue from where it had stopped, without generating Sobol trials again. It also maintains compatibility with the workflow mentioned in 2 (the user can get a reference to the AxClient in the input script as soon as the generator is initialized). This approach is also more flexible, as it does not require the user to decide in advance whether external data will be given. This is useful for interactive optimization on a notebook (e.g., with `n_init=6`, the user can first run 2 Sobol trials, then add an external one, then continue with the remaining 3 Sobol trials). This was the implemented option.