### PR TITLE
Support changing the range and fixing the value of `VaryingParameter`s

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -13,10 +13,10 @@ jobs:
       id-token: write
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.8
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.11
     - name: Install pypa/build
       run: >-
         python3 -m

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', 3.11]
+        python-version: [3.9, '3.10', 3.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.8"
+    python: "3.11"
     nodejs: "16"
 
 # Build documentation in the docs/ directory with Sphinx

--- a/optimas/core/parameter.py
+++ b/optimas/core/parameter.py
@@ -59,11 +59,13 @@ class VaryingParameter(Parameter):
         dtype: Optional[np.dtype] = float,
     ) -> None:
         super().__init__(name, dtype)
+        self._check_range(lower_bound, upper_bound)
         self._lower_bound = lower_bound
         self._upper_bound = upper_bound
         self._is_fidelity = is_fidelity
         self._fidelity_target_value = fidelity_target_value
         self._default_value = default_value
+        self._is_fixed = False
 
     @property
     def lower_bound(self) -> float:
@@ -89,6 +91,52 @@ class VaryingParameter(Parameter):
     def default_value(self) -> float:
         """Get the default value of the varying parameter."""
         return self._default_value
+    
+    @property
+    def is_fixed(self) -> bool:
+        """Get whether the parameter is fixed to a certain value."""
+        return self._is_fixed
+    
+    def update_range(self, lower_bound: float, upper_bound: float) -> None:
+        """Update range of the parameter.
+
+        Parameters
+        ----------
+        lower_bound, upper_bound : float
+            Lower and upper bounds of the range in which the parameter can vary.
+        """
+        self._check_range(lower_bound, upper_bound)
+        self._lower_bound = lower_bound
+        self._upper_bound = upper_bound
+    
+    def fix_value(self, value: float) -> None:
+        """Fix the value of the parameter.
+
+        The value must be within the range of the parameter.
+
+        Parameters
+        ----------
+        value : float
+            The value to which the parameter will be fixed.
+        """
+        if value < self.lower_bound or value > self.upper_bound:
+            raise ValueError(
+                f"The value {value} is outside of the range of parameter "
+                f"{self.name}: [{self.lower_bound},{self.upper_bound}]"
+            )
+        self._default_value = value
+        self._is_fixed = True
+
+    def free_value(self) -> None:
+        """Free the value of the parameter."""
+        self._is_fixed = False
+
+    def _check_range(self, lower_bound, upper_bound):
+        if upper_bound <= lower_bound:
+            raise ValueError(
+                "Inconsistent range bounds. "
+                f"Upper bound ({upper_bound}) < lower bound ({lower_bound})."
+            )
 
 
 class TrialParameter(Parameter):

--- a/optimas/generators/ax/base.py
+++ b/optimas/generators/ax/base.py
@@ -50,6 +50,13 @@ class AxGenerator(Generator):
         For some generators, it might be necessary to attach additional
         parameters to the trials. If so, they can be given here as a list.
         By default, ``None``.
+    allow_fixed_parameters : bool, optional
+        Whether the generator supports ``VaryingParameter``s whose value
+        has been fixed. By default, False.
+    allow_updating_parameters : list of TrialParameter
+        Whether the generator supports updating the ``VaryingParameter``s.
+        If so, the `_update_parameter` method must be implemented.
+        By default, False.
 
     """
 
@@ -65,6 +72,8 @@ class AxGenerator(Generator):
         model_save_period: Optional[int] = 5,
         model_history_dir: Optional[str] = "model_history",
         custom_trial_parameters: Optional[TrialParameter] = None,
+        allow_fixed_parameters: Optional[bool] = False,
+        allow_updating_parameters: Optional[bool] = False,
     ) -> None:
         super().__init__(
             varying_parameters=varying_parameters,
@@ -77,6 +86,8 @@ class AxGenerator(Generator):
             model_save_period=model_save_period,
             model_history_dir=model_history_dir,
             custom_trial_parameters=custom_trial_parameters,
+            allow_fixed_parameters=allow_fixed_parameters,
+            allow_updating_parameters=allow_updating_parameters
         )
         self._determine_torch_device()
 

--- a/optimas/generators/ax/service/base.py
+++ b/optimas/generators/ax/service/base.py
@@ -3,6 +3,7 @@
 from typing import List, Optional, Dict
 import os
 
+import torch
 from packaging import version
 from ax.version import version as ax_version
 from ax.core.observation import ObservationFeatures
@@ -145,9 +146,14 @@ class AxServiceGenerator(AxGenerator):
 
     def _create_ax_client(self) -> AxClient:
         """Create Ax client."""
+        bo_model_kwargs = {
+            "torch_dtype": torch.double,
+            "torch_device": torch.device(self.torch_device),
+            "fit_out_of_design": True,  # Support updating search space.
+        }
         ax_client = AxClient(
             generation_strategy=GenerationStrategy(
-                self._create_generation_steps()
+                self._create_generation_steps(bo_model_kwargs)
             ),
             verbose_logging=False,
         )
@@ -184,7 +190,9 @@ class AxServiceGenerator(AxGenerator):
             objectives[obj.name] = ObjectiveProperties(minimize=obj.minimize)
         return objectives
 
-    def _create_generation_steps(self) -> List[GenerationStep]:
+    def _create_generation_steps(
+        self, bo_model_kwargs: Dict
+    ) -> List[GenerationStep]:
         """Create generation steps (must be implemented by subclasses)."""
         raise NotImplementedError
 

--- a/optimas/generators/ax/service/base.py
+++ b/optimas/generators/ax/service/base.py
@@ -107,9 +107,15 @@ class AxServiceGenerator(AxGenerator):
     def _ask(self, trials: List[Trial]) -> List[Trial]:
         """Fill in the parameter values of the requested trials."""
         for trial in trials:
-            parameters, trial_id = self._ax_client.get_next_trial(
-                fixed_features=self._fixed_features
-            )
+            try:
+                parameters, trial_id = self._ax_client.get_next_trial(
+                    fixed_features=self._fixed_features
+                )
+            # Occurs when not using a CustomAxClient (i.e., when the AxClient
+            # is provided by the user using an AxClientGenerator). In that
+            # case, there is also no need to support FixedFeatures.
+            except TypeError:
+                parameters, trial_id = self._ax_client.get_next_trial()
             trial.parameter_values = [
                 parameters.get(var.name) for var in self._varying_parameters
             ]

--- a/optimas/generators/ax/service/base.py
+++ b/optimas/generators/ax/service/base.py
@@ -44,6 +44,11 @@ class AxServiceGenerator(AxGenerator):
     enforce_n_init : bool, optional
         Whether to enforce the generation of `n_init` Sobol trials, even if
         external data is supplied. By default, ``False``.
+    fit_out_of_design : bool, optional
+        Whether to fit the surrogate model taking into account evaluations
+        outside of the range of the varying parameters. This can be useful
+        if the range of parameter has been reduced during the optimization.
+        By default, False.
     use_cuda : bool, optional
         Whether to allow the generator to run on a CUDA GPU. By default
         ``False``.
@@ -72,6 +77,7 @@ class AxServiceGenerator(AxGenerator):
         analyzed_parameters: Optional[List[Parameter]] = None,
         n_init: Optional[int] = 4,
         enforce_n_init: Optional[bool] = False,
+        fit_out_of_design: Optional[bool] = False,
         use_cuda: Optional[bool] = False,
         gpu_id: Optional[int] = 0,
         dedicated_resources: Optional[bool] = False,
@@ -94,6 +100,7 @@ class AxServiceGenerator(AxGenerator):
         )
         self._n_init = n_init
         self._enforce_n_init = enforce_n_init
+        self._fit_out_of_design = fit_out_of_design
         self._ax_client = self._create_ax_client()
         self._fixed_features = None
 
@@ -149,7 +156,7 @@ class AxServiceGenerator(AxGenerator):
         bo_model_kwargs = {
             "torch_dtype": torch.double,
             "torch_device": torch.device(self.torch_device),
-            "fit_out_of_design": True,  # Support updating search space.
+            "fit_out_of_design": self._fit_out_of_design,
         }
         ax_client = AxClient(
             generation_strategy=GenerationStrategy(

--- a/optimas/generators/ax/service/custom_ax.py
+++ b/optimas/generators/ax/service/custom_ax.py
@@ -1,0 +1,142 @@
+"""Contains the definition of custom Ax classes."""
+
+from typing import Optional, Tuple
+
+from ax.service.ax_client import (
+    AxClient,
+    FixedFeatures,
+    GeneratorRun,
+    InstantiationBase,
+    MaxParallelismReachedException,
+    ObservationFeatures,
+    OptimizationShouldStop,
+    TParameterization,
+    logger,
+    round_floats_for_logging,
+    manual_seed,
+    not_none,
+    retry_on_exception,
+    CHOLESKY_ERROR_ANNOTATION,
+)
+
+
+class CustomAxClient(AxClient):
+    """Custom AxClient that supports `fixed_features` in `gen_next_trial`.
+
+    This class can be removed if https://github.com/facebook/Ax/pull/2015
+    is merged.
+    """
+
+    @retry_on_exception(
+        logger=logger,
+        exception_types=(RuntimeError,),
+        check_message_contains=["Cholesky", "cholesky"],
+        suppress_all_errors=False,
+        wrap_error_message_in=CHOLESKY_ERROR_ANNOTATION,
+    )
+    def get_next_trial(
+        self,
+        ttl_seconds: Optional[int] = None,
+        force: bool = False,
+        fixed_features: Optional[ObservationFeatures] = None,
+    ) -> Tuple[TParameterization, int]:
+        """
+        Generate trial with the next set of parameters to try in the iteration process.
+
+        Note: Service API currently supports only 1-arm trials.
+
+        Args:
+            ttl_seconds: If specified, will consider the trial failed after this
+                many seconds. Used to detect dead trials that were not marked
+                failed properly.
+            force: If set to True, this function will bypass the global stopping
+                strategy's decision and generate a new trial anyway.
+            fixed_features: An ObservationFeatures object containing any
+                features that should be fixed at specified values during
+                generation.
+
+        Returns:
+            Tuple of trial parameterization, trial index
+        """
+
+        # Check if the global stopping strategy suggests to stop the optimization.
+        # This is needed only if there is actually a stopping strategy specified,
+        # and if this function is not forced to generate a new trial.
+        if self.global_stopping_strategy and (not force):
+            # The strategy itself will check if enough trials have already been
+            # completed.
+            (
+                stop_optimization,
+                global_stopping_message,
+            ) = self.global_stopping_strategy.should_stop_optimization(
+                experiment=self.experiment
+            )
+            if stop_optimization:
+                raise OptimizationShouldStop(message=global_stopping_message)
+
+        try:
+            trial = self.experiment.new_trial(
+                generator_run=self._gen_new_generator_run(
+                    fixed_features=fixed_features
+                ),
+                ttl_seconds=ttl_seconds,
+            )
+        except MaxParallelismReachedException as e:
+            if self._early_stopping_strategy is not None:
+                e.message += (  # noqa: B306
+                    " When stopping trials early, make sure to call `stop_trial_early` "
+                    "on the stopped trial."
+                )
+            raise e
+        logger.info(
+            f"Generated new trial {trial.index} with parameters "
+            f"{round_floats_for_logging(item=not_none(trial.arm).parameters)}."
+        )
+        trial.mark_running(no_runner_required=True)
+        self._save_or_update_trial_in_db_if_possible(
+            experiment=self.experiment,
+            trial=trial,
+        )
+        # TODO[T79183560]: Ensure correct handling of generator run when using
+        # foreign keys.
+        self._update_generation_strategy_in_db_if_possible(
+            generation_strategy=self.generation_strategy,
+            new_generator_runs=[self.generation_strategy._generator_runs[-1]],
+        )
+        return not_none(trial.arm).parameters, trial.index
+
+    def _gen_new_generator_run(
+        self, n: int = 1, fixed_features: Optional[ObservationFeatures] = None
+    ) -> GeneratorRun:
+        """Generate new generator run for this experiment.
+
+        Args:
+            n: Number of arms to generate.
+            fixed_features: An ObservationFeatures object containing any
+                features that should be fixed at specified values during
+                generation.
+        """
+        # If random seed is not set for this optimization, context manager does
+        # nothing; otherwise, it sets the random seed for torch, but only for the
+        # scope of this call. This is important because torch seed is set globally,
+        # so if we just set the seed without the context manager, it can have
+        # serious negative impact on the performance of the models that employ
+        # stochasticity.
+
+        fixed_feats = InstantiationBase.make_fixed_observation_features(
+            fixed_features=FixedFeatures(
+                parameters={},
+                trial_index=self._get_last_completed_trial_index(),
+            )
+        )
+        if fixed_features:
+            fixed_feats.update_features(fixed_features)
+        with manual_seed(seed=self._random_seed):
+            return not_none(self.generation_strategy).gen(
+                experiment=self.experiment,
+                n=n,
+                pending_observations=self._get_pending_observation_features(
+                    experiment=self.experiment
+                ),
+                fixed_features=fixed_feats,
+            )

--- a/optimas/generators/ax/service/custom_ax.py
+++ b/optimas/generators/ax/service/custom_ax.py
@@ -40,10 +40,9 @@ class CustomAxClient(AxClient):
         force: bool = False,
         fixed_features: Optional[ObservationFeatures] = None,
     ) -> Tuple[TParameterization, int]:
-        """Modified method that supports `fixed_features` as argument.
+        """Generate trial with the next set of parameters to try.
 
-        Generate trial with the next set of parameters to try in the iteration
-        process.
+        This is a modified method that supports `fixed_features` as argument.
 
         Note: Service API currently supports only 1-arm trials.
 

--- a/optimas/generators/ax/service/custom_ax.py
+++ b/optimas/generators/ax/service/custom_ax.py
@@ -2,6 +2,7 @@
 
 from typing import Optional, Tuple
 
+import numpy as np
 from ax.service.ax_client import (
     AxClient,
     GeneratorRun,
@@ -15,10 +16,6 @@ from ax.service.ax_client import (
     not_none,
     retry_on_exception,
     CHOLESKY_ERROR_ANNOTATION,
-)
-from ax.service.utils.instantiation import (
-    FixedFeatures,
-    InstantiationBase,
 )
 
 
@@ -125,11 +122,9 @@ class CustomAxClient(AxClient):
         # serious negative impact on the performance of the models that employ
         # stochasticity.
 
-        fixed_feats = InstantiationBase.make_fixed_observation_features(
-            fixed_features=FixedFeatures(
-                parameters={},
-                trial_index=self._get_last_completed_trial_index(),
-            )
+        fixed_feats = ObservationFeatures(
+            parameters={},
+            trial_index=np.int64(self._get_last_completed_trial_index())
         )
         if fixed_features:
             fixed_feats.update_features(fixed_features)

--- a/optimas/generators/ax/service/custom_ax.py
+++ b/optimas/generators/ax/service/custom_ax.py
@@ -40,28 +40,36 @@ class CustomAxClient(AxClient):
         force: bool = False,
         fixed_features: Optional[ObservationFeatures] = None,
     ) -> Tuple[TParameterization, int]:
-        """
-        Generate trial with the next set of parameters to try in the iteration process.
+        """Modified method that supports `fixed_features` as argument.
+
+        Generate trial with the next set of parameters to try in the iteration
+        process.
 
         Note: Service API currently supports only 1-arm trials.
 
-        Args:
-            ttl_seconds: If specified, will consider the trial failed after this
+        Parameters
+        ----------
+            ttl_seconds : int, optional
+                If specified, will consider the trial failed after this
                 many seconds. Used to detect dead trials that were not marked
                 failed properly.
-            force: If set to True, this function will bypass the global stopping
+            force : bool, optional
+                If set to True, this function will bypass the global stopping
                 strategy's decision and generate a new trial anyway.
-            fixed_features: An ObservationFeatures object containing any
+            fixed_features : ObservationFeatures, optional
+                An ObservationFeatures object containing any
                 features that should be fixed at specified values during
                 generation.
 
-        Returns:
+        Returns
+        -------
             Tuple of trial parameterization, trial index
         """
-
-        # Check if the global stopping strategy suggests to stop the optimization.
-        # This is needed only if there is actually a stopping strategy specified,
-        # and if this function is not forced to generate a new trial.
+        # Check if the global stopping strategy suggests to stop the
+        # optimization.
+        # This is needed only if there is actually a stopping strategy
+        # specified, and if this function is not forced to generate a new
+        # trial.
         if self.global_stopping_strategy and (not force):
             # The strategy itself will check if enough trials have already been
             # completed.
@@ -84,8 +92,8 @@ class CustomAxClient(AxClient):
         except MaxParallelismReachedException as e:
             if self._early_stopping_strategy is not None:
                 e.message += (  # noqa: B306
-                    " When stopping trials early, make sure to call `stop_trial_early` "
-                    "on the stopped trial."
+                    " When stopping trials early, make sure to call "
+                    "`stop_trial_early` on the stopped trial."
                 )
             raise e
         logger.info(
@@ -110,18 +118,21 @@ class CustomAxClient(AxClient):
     ) -> GeneratorRun:
         """Generate new generator run for this experiment.
 
-        Args:
-            n: Number of arms to generate.
-            fixed_features: An ObservationFeatures object containing any
+        Parameters
+        ----------
+            n: int, optional
+                Number of arms to generate.
+            fixed_features: ObservationFeatures, optional,
+                An ObservationFeatures object containing any
                 features that should be fixed at specified values during
                 generation.
         """
         # If random seed is not set for this optimization, context manager does
-        # nothing; otherwise, it sets the random seed for torch, but only for the
-        # scope of this call. This is important because torch seed is set globally,
-        # so if we just set the seed without the context manager, it can have
-        # serious negative impact on the performance of the models that employ
-        # stochasticity.
+        # nothing; otherwise, it sets the random seed for torch, but only for
+        # the scope of this call. This is important because torch seed is set
+        # globally, so if we just set the seed without the context manager, it
+        # can have serious negative impact on the performance of the models
+        # that employ stochasticity.
 
         fixed_feats = InstantiationBase.make_fixed_observation_features(
             fixed_features=FixedFeatures(

--- a/optimas/generators/ax/service/custom_ax.py
+++ b/optimas/generators/ax/service/custom_ax.py
@@ -2,10 +2,11 @@
 
 from typing import Optional, Tuple
 
-import numpy as np
 from ax.service.ax_client import (
     AxClient,
+    FixedFeatures,
     GeneratorRun,
+    InstantiationBase,
     MaxParallelismReachedException,
     ObservationFeatures,
     OptimizationShouldStop,
@@ -122,9 +123,10 @@ class CustomAxClient(AxClient):
         # serious negative impact on the performance of the models that employ
         # stochasticity.
 
-        fixed_feats = ObservationFeatures(
-            parameters={},
-            trial_index=np.int64(self._get_last_completed_trial_index())
+        fixed_feats = InstantiationBase.make_fixed_observation_features(
+            fixed_features=FixedFeatures(
+                parameters={}, trial_index=self._get_last_completed_trial_index()
+            )
         )
         if fixed_features:
             fixed_feats.update_features(fixed_features)

--- a/optimas/generators/ax/service/custom_ax.py
+++ b/optimas/generators/ax/service/custom_ax.py
@@ -4,9 +4,7 @@ from typing import Optional, Tuple
 
 from ax.service.ax_client import (
     AxClient,
-    FixedFeatures,
     GeneratorRun,
-    InstantiationBase,
     MaxParallelismReachedException,
     ObservationFeatures,
     OptimizationShouldStop,
@@ -17,6 +15,10 @@ from ax.service.ax_client import (
     not_none,
     retry_on_exception,
     CHOLESKY_ERROR_ANNOTATION,
+)
+from ax.service.utils.instantiation import (
+    FixedFeatures,
+    InstantiationBase,
 )
 
 

--- a/optimas/generators/ax/service/custom_ax.py
+++ b/optimas/generators/ax/service/custom_ax.py
@@ -125,7 +125,8 @@ class CustomAxClient(AxClient):
 
         fixed_feats = InstantiationBase.make_fixed_observation_features(
             fixed_features=FixedFeatures(
-                parameters={}, trial_index=self._get_last_completed_trial_index()
+                parameters={},
+                trial_index=self._get_last_completed_trial_index(),
             )
         )
         if fixed_features:

--- a/optimas/generators/ax/service/multi_fidelity.py
+++ b/optimas/generators/ax/service/multi_fidelity.py
@@ -87,7 +87,6 @@ class AxMultiFidelityGenerator(AxServiceGenerator):
 
     def _create_generation_steps(self) -> List[GenerationStep]:
         """Create generation steps for multifidelity optimization."""
-
         # Make generation strategy:
         steps = []
 

--- a/optimas/generators/ax/service/multi_fidelity.py
+++ b/optimas/generators/ax/service/multi_fidelity.py
@@ -29,6 +29,11 @@ class AxMultiFidelityGenerator(AxServiceGenerator):
     enforce_n_init : bool, optional
         Whether to enforce the generation of `n_init` Sobol trials, even if
         external data is supplied. By default, ``False``.
+    fit_out_of_design : bool, optional
+        Whether to fit the surrogate model taking into account evaluations
+        outside of the range of the varying parameters. This can be useful
+        if the range of parameter has been reduced during the optimization.
+        By default, False.
     fidel_cost_intercept : float, optional
         The cost intercept for the affine cost of the form
         `cost_intercept + n`, where `n` is the number of generated points.
@@ -61,6 +66,7 @@ class AxMultiFidelityGenerator(AxServiceGenerator):
         analyzed_parameters: Optional[List[Parameter]] = None,
         n_init: Optional[int] = 4,
         enforce_n_init: Optional[bool] = False,
+        fit_out_of_design: Optional[bool] = False,
         fidel_cost_intercept: Optional[float] = 1.0,
         use_cuda: Optional[bool] = False,
         gpu_id: Optional[int] = 0,
@@ -76,6 +82,7 @@ class AxMultiFidelityGenerator(AxServiceGenerator):
             analyzed_parameters=analyzed_parameters,
             n_init=n_init,
             enforce_n_init=enforce_n_init,
+            fit_out_of_design=fit_out_of_design,
             use_cuda=use_cuda,
             gpu_id=gpu_id,
             dedicated_resources=dedicated_resources,

--- a/optimas/generators/ax/service/single_fidelity.py
+++ b/optimas/generators/ax/service/single_fidelity.py
@@ -3,13 +3,8 @@
 from typing import List, Optional
 
 import torch
-from ax.service.ax_client import AxClient
-from ax.modelbridge.generation_strategy import (
-    GenerationStep,
-    GenerationStrategy,
-)
+from ax.modelbridge.generation_strategy import GenerationStep
 from ax.modelbridge.registry import Models
-from ax.service.utils.instantiation import ObjectiveProperties
 
 from optimas.core import Objective, VaryingParameter, Parameter
 from .base import AxServiceGenerator
@@ -110,25 +105,14 @@ class AxSingleFidelityGenerator(AxServiceGenerator):
             model_history_dir=model_history_dir,
         )
 
-    def _create_ax_client(self):
-        """Create single-fidelity Ax client."""
-        # Create parameter list.
-        parameters = list()
-        for var in self._varying_parameters:
-            parameters.append(
-                {
-                    "name": var.name,
-                    "type": "range",
-                    "bounds": [var.lower_bound, var.upper_bound],
-                    # Suppresses warning when the type is not given explicitly
-                    "value_type": var.dtype.__name__,
-                }
-            )
+    def _create_generation_steps(self) -> List[GenerationStep]:
+        """Create generation steps for single-fidelity optimization."""
 
         # Select BO model.
         model_kwargs = {
             "torch_dtype": torch.double,
             "torch_device": torch.device(self.torch_device),
+            "fit_out_of_design": True,  # Support updating search space.
         }
         if self._fully_bayesian:
             if len(self.objectives) > 1:
@@ -167,16 +151,4 @@ class AxSingleFidelityGenerator(AxServiceGenerator):
             )
         )
 
-        gs = GenerationStrategy(steps)
-
-        ax_objectives = {}
-        for obj in self.objectives:
-            ax_objectives[obj.name] = ObjectiveProperties(minimize=obj.minimize)
-
-        # Create client and experiment.
-        ax_client = AxClient(generation_strategy=gs, verbose_logging=False)
-        ax_client.create_experiment(
-            parameters=parameters, objectives=ax_objectives
-        )
-
-        return ax_client
+        return steps

--- a/optimas/generators/ax/service/single_fidelity.py
+++ b/optimas/generators/ax/service/single_fidelity.py
@@ -107,7 +107,6 @@ class AxSingleFidelityGenerator(AxServiceGenerator):
 
     def _create_generation_steps(self) -> List[GenerationStep]:
         """Create generation steps for single-fidelity optimization."""
-
         # Select BO model.
         model_kwargs = {
             "torch_dtype": torch.double,

--- a/optimas/generators/ax/service/single_fidelity.py
+++ b/optimas/generators/ax/service/single_fidelity.py
@@ -38,6 +38,11 @@ class AxSingleFidelityGenerator(AxServiceGenerator):
     enforce_n_init : bool, optional
         Whether to enforce the generation of `n_init` Sobol trials, even if
         external data is supplied. By default, ``False``.
+    fit_out_of_design : bool, optional
+        Whether to fit the surrogate model taking into account evaluations
+        outside of the range of the varying parameters. This can be useful
+        if the range of parameter has been reduced during the optimization.
+        By default, False.
     fully_bayesian : bool, optional
         Whether to optimize the hyperparameters of the GP with a fully
         Bayesian approach (using SAAS priors) instead of maximizing
@@ -81,6 +86,7 @@ class AxSingleFidelityGenerator(AxServiceGenerator):
         analyzed_parameters: Optional[List[Parameter]] = None,
         n_init: Optional[int] = 4,
         enforce_n_init: Optional[bool] = False,
+        fit_out_of_design: Optional[bool] = False,
         fully_bayesian: Optional[bool] = False,
         use_cuda: Optional[bool] = False,
         gpu_id: Optional[int] = 0,
@@ -96,6 +102,7 @@ class AxSingleFidelityGenerator(AxServiceGenerator):
             analyzed_parameters=analyzed_parameters,
             n_init=n_init,
             enforce_n_init=enforce_n_init,
+            fit_out_of_design=fit_out_of_design,
             use_cuda=use_cuda,
             gpu_id=gpu_id,
             dedicated_resources=dedicated_resources,

--- a/optimas/generators/base.py
+++ b/optimas/generators/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 import os
+from copy import deepcopy
 from typing import List, Dict, Optional, Union
 
 import numpy as np
@@ -87,8 +88,10 @@ class Generator:
     ) -> None:
         if objectives is None:
             objectives = [Objective()]
-        self._varying_parameters = varying_parameters
-        self._objectives = objectives
+        # Store copies to prevent unexpected behavior if parameters are changed
+        # externally.
+        self._varying_parameters = deepcopy(varying_parameters)
+        self._objectives = deepcopy(objectives)
         self._constraints = constraints
         self._analyzed_parameters = (
             [] if analyzed_parameters is None else analyzed_parameters

--- a/optimas/generators/base.py
+++ b/optimas/generators/base.py
@@ -59,6 +59,13 @@ class Generator:
         For some generators, it might be necessary to attach additional
         parameters to the trials. If so, they can be given here as a list.
         By default, ``None``.
+    allow_fixed_parameters : bool, optional
+        Whether the generator supports ``VaryingParameter``s whose value
+        has been fixed. By default, False.
+    allow_updating_parameters : list of TrialParameter
+        Whether the generator supports updating the ``VaryingParameter``s.
+        If so, the `_update_parameter` method must be implemented.
+        By default, False.
 
     """
 
@@ -75,6 +82,8 @@ class Generator:
         model_save_period: Optional[int] = 5,
         model_history_dir: Optional[str] = "model_history",
         custom_trial_parameters: Optional[List[TrialParameter]] = None,
+        allow_fixed_parameters: Optional[bool] = False,
+        allow_updating_parameters: Optional[bool] = False,
     ) -> None:
         if objectives is None:
             objectives = [Objective()]
@@ -94,10 +103,13 @@ class Generator:
         self._custom_trial_parameters = (
             [] if custom_trial_parameters is None else custom_trial_parameters
         )
+        self._allow_fixed_parameters = allow_fixed_parameters
+        self._allow_updating_parameters = allow_updating_parameters
         self._gen_function = persistent_generator
         self._given_trials = []  # Trials given for evaluation.
         self._queued_trials = []  # Trials queued to be given for evaluation.
         self._trial_count = 0
+        self._check_parameters(self._varying_parameters)
 
     @property
     def varying_parameters(self) -> List[VaryingParameter]:
@@ -291,6 +303,41 @@ class Generator:
         for trial in self._given_trials + self._queued_trials:
             if trial.index == trial_index:
                 return trial
+
+    def update_parameter(self, parameter: VaryingParameter):
+        """Update a varying parameter of the generator.
+
+        This method should be called, for example, after updating the range
+        of the parameter, or fixing its value.
+
+        Parameters
+        ----------
+        parameter : VaryingParameter
+            The updated parameter. It must have the name of one of the
+            existing parameters.
+        """
+        if not self._allow_updating_parameters:
+            raise ValueError(
+                f"The parameters of a {self.__class__.__name__} cannot be "
+                "updated."
+            )
+        if not isinstance(parameter, VaryingParameter):
+            raise ValueError(
+                "Updated parameter must be a VaryingParameter, not a "
+                f"{type(parameter)}."
+            )
+        gen_vps = [vp.name for vp in self._varying_parameters]
+        if parameter.name not in gen_vps:
+            raise ValueError(
+                f"Cannot update parameter {parameter.name}. "
+                f"Available parameters are {gen_vps}."
+            )
+        self._check_parameters([parameter])
+        for i, vp in enumerate(self._varying_parameters):
+            if vp.name == parameter.name:
+                self._varying_parameters[i] = parameter
+                break
+        self._update_parameter(parameter)
 
     def _add_trial_to_queue(
         self, trial: Trial, queue_index: Optional[int] = None
@@ -523,3 +570,21 @@ class Generator:
     def _save_model_to_file(self):
         """Save model method to be implemented by the Generator subclasses."""
         pass
+
+    def _update_parameter(self, parameter: VaryingParameter):
+        """Perform the operations needed by to update the parameter.
+        
+        This method must be implemented by the subclasses if
+        `allow_updating_parameters=True`.
+        """
+        raise NotImplementedError
+
+    def _check_parameters(self, parameters: List[VaryingParameter]):
+        """Check the validity of the varying parameters."""
+        if not self._allow_fixed_parameters:
+            for vp in parameters:
+                if vp.is_fixed:
+                    raise ValueError(
+                        f"{self.__class__.__name__} does not support fixing "
+                        "the value of a VaryingParameter."
+                    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     {name = 'Optimas Developers', email = 'angel.ferran.pousa@desy.de'},
 ]
 readme = 'README.md'
-requires-python = '>=3.8'
+requires-python = '>=3.9'
 keywords = ['optimization', 'scale', 'bayesian']
 license = {text = 'BSD-3-Clause-LBNL'}
 classifiers = [
@@ -17,7 +17,6 @@ classifiers = [
     'Intended Audience :: Science/Research',
     'Topic :: Scientific/Engineering',
     'Operating System :: OS Independent',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
@@ -25,7 +24,7 @@ classifiers = [
 dependencies = [
     'libensemble >= 1.1.0',
     'jinja2',
-    'ax-platform >= 0.2.9',
+    'ax-platform >= 0.3.4',
     'mpi4py',
 ]
 dynamic = ['version']
@@ -50,7 +49,7 @@ include = [
 
 [tool.black]
 line-length = 80
-target-version = ['py38', 'py39', 'py310', 'py311']
+target-version = ['py39', 'py310', 'py311']
 
 [tool.pydocstyle]
 convention = "numpy"

--- a/tests/test_ax_generators.py
+++ b/tests/test_ax_generators.py
@@ -217,6 +217,54 @@ def test_ax_single_fidelity_moo_fb():
     assert n_ax_trials == exploration.history.shape[0]
 
 
+def test_ax_single_fidelity_fixed_params():
+    """
+    Test that an exploration with a single-fidelity generator runs
+    and that the generator and Ax client are updated after running.
+    """
+
+    var1 = VaryingParameter("x0", -50.0, 5.0)
+    var2 = VaryingParameter("x1", -5.0, 15.0)
+    obj = Objective("f", minimize=False)
+
+    gen = AxSingleFidelityGenerator(
+        varying_parameters=[var1, var2], objectives=[obj]
+    )
+    ev = FunctionEvaluator(function=eval_func_sf)
+    exploration = Exploration(
+        generator=gen,
+        evaluator=ev,
+        sim_workers=2,
+        exploration_dir_path="./tests_output/test_ax_single_fidelity_fp",
+    )
+
+    # Run exploration.
+    exploration.run(n_evals=10)
+
+    # Update range of x0 and run 10 evals.
+    var1.update_range(-20., 0.)
+    gen.update_parameter(var1)
+    exploration.run(n_evals=10)
+    assert all(exploration.history["x0"][-10:] >= -20)
+    assert all(exploration.history["x0"][-10:] <= 0.)
+
+    # Fix of x0 and run 5 evals.
+    var1.fix_value(-9)
+    gen.update_parameter(var1)
+    exploration.run(n_evals=5)
+    assert all(exploration.history["x0"][-5:] == -9)
+
+    # Evaluate a custom trial.
+    exploration.evaluate_trials([{"x0": -7., "x1":10.}])
+    assert exploration.history["x0"].to_numpy()[-1] == -7
+
+    # Free value and run 3 evals.
+    var1.free_value()
+    gen.update_parameter(var1)
+    exploration.run(n_evals=3)
+    assert all(exploration.history["x0"][-3:] != -9)
+
+
 def test_ax_multi_fidelity():
     """Test that an exploration with a multifidelity generator runs"""
 
@@ -520,6 +568,7 @@ if __name__ == "__main__":
     test_ax_single_fidelity_moo()
     test_ax_single_fidelity_fb()
     test_ax_single_fidelity_moo_fb()
+    test_ax_single_fidelity_fixed_params()
     test_ax_multi_fidelity()
     test_ax_multitask()
     test_ax_client()

--- a/tests/test_ax_generators.py
+++ b/tests/test_ax_generators.py
@@ -217,10 +217,10 @@ def test_ax_single_fidelity_moo_fb():
     assert n_ax_trials == exploration.history.shape[0]
 
 
-def test_ax_single_fidelity_fixed_params():
+def test_ax_single_fidelity_updated_params():
     """
     Test that an exploration with a single-fidelity generator runs
-    and that the generator and Ax client are updated after running.
+    as expected when the varing parameters are updated.
     """
 
     var1 = VaryingParameter("x0", -50.0, 5.0)
@@ -228,14 +228,16 @@ def test_ax_single_fidelity_fixed_params():
     obj = Objective("f", minimize=False)
 
     gen = AxSingleFidelityGenerator(
-        varying_parameters=[var1, var2], objectives=[obj]
+        varying_parameters=[var1, var2],
+        objectives=[obj],
+        fit_out_of_design=True,
     )
     ev = FunctionEvaluator(function=eval_func_sf)
     exploration = Exploration(
         generator=gen,
         evaluator=ev,
         sim_workers=2,
-        exploration_dir_path="./tests_output/test_ax_single_fidelity_fp",
+        exploration_dir_path="./tests_output/test_ax_single_fidelity_up",
     )
 
     # Run exploration.
@@ -568,7 +570,7 @@ if __name__ == "__main__":
     test_ax_single_fidelity_moo()
     test_ax_single_fidelity_fb()
     test_ax_single_fidelity_moo_fb()
-    test_ax_single_fidelity_fixed_params()
+    test_ax_single_fidelity_updated_params()
     test_ax_multi_fidelity()
     test_ax_multitask()
     test_ax_client()


### PR DESCRIPTION
This PR adds support for interactive explorations where the range of varying parameters can be updated, or their values fixed. For example:

```python
var1 = VaryingParameter("x0", -50.0, 5.0)
var2 = VaryingParameter("x1", -5.0, 15.0)
obj = Objective("f", minimize=False)

generator = AxSingleFidelityGenerator(
    varying_parameters=[var1, var2],
    objectives=[obj],
    fit_out_of_design=True,
)
evaluator = FunctionEvaluator(function=eval_func_sf)
exploration = Exploration(
    generator=generator,
    evaluator=evaluator,
    sim_workers=2,
)

# Run 5 evals with default parameters
exploration.run(n_evals=5)

# Change range of x0 and run 10 evals
var1.update_range(-20., 0.)
generator.update_parameter(var1)
exploration.run(n_evals=10)

# Fix value of x0 and run 5 evals
var1.fix_value(-9)
generator.update_parameter(var1)
exploration.run(n_evals=5)

# Free value of x0 and run 5 evals
var1.free_value()
generator.update_parameter(var1)
exploration.run(n_evals=5)
```

Currently, only the generators based on the Ax service API support updating the parameters. Support for other generators will be added in future PRs.

In order to support VaryingParameters with a fixed value, a set of `fixed_features` needs to be passed to Ax. This, however, is not currently possible with the Service API (unless https://github.com/facebook/Ax/pull/2015 or something similar is merged). Therefore, this PR defines a `CustomAxClient` derived class that modifies `get_next_trial` to support `fixed_features`.

## Other changes
- The `CustomAxClient` requires `Ax>=0.3.4` (and therefore `python>=3.9`), which means that this PR also drops support for older Ax versions and Python 3.8.
- The logic of how we create the `AxClient`s has been simplified. Now the subclasses of the `AxServiceGenerator` only need to define the list of `GenerationStep`s, instead of creating an `AxClient`. This avoids code duplication.
