### PR TITLE
Fix bug with parameter type in Ax generators

### DIFF
--- a/optimas/evaluators/base.py
+++ b/optimas/evaluators/base.py
@@ -67,11 +67,11 @@ class Evaluator:
             # May be a 1D array.
             "in": [var.name for var in varying_parameters],
             "out": (
-                [(obj.name, float) for obj in objectives]
+                [(obj.name, obj.dtype) for obj in objectives]
                 # f is the single float output that LibEnsemble minimizes.
                 + [(par.name, par.dtype) for par in analyzed_parameters]
                 # input parameters
-                + [(var.name, float) for var in varying_parameters]
+                + [(var.name, var.dtype) for var in varying_parameters]
             ),
             "user": {
                 "n_procs": self._n_procs,

--- a/optimas/generators/ax/service/base.py
+++ b/optimas/generators/ax/service/base.py
@@ -188,6 +188,7 @@ class AxServiceGenerator(AxGenerator):
                     "bounds": [var.lower_bound, var.upper_bound],
                     "is_fidelity": var.is_fidelity,
                     "target_value": var.fidelity_target_value,
+                    "value_type": var.dtype.__name__,
                 }
             )
             if var.is_fixed:

--- a/optimas/generators/base.py
+++ b/optimas/generators/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 import os
+from copy import deepcopy
 from typing import List, Dict, Optional, Union
 
 import numpy as np
@@ -87,8 +88,10 @@ class Generator:
     ) -> None:
         if objectives is None:
             objectives = [Objective()]
-        self._varying_parameters = varying_parameters
-        self._objectives = objectives
+        # Store copies to prevent unexpected behavior if parameters are changed
+        # externally.
+        self._varying_parameters = deepcopy(varying_parameters)
+        self._objectives = deepcopy(objectives)
         self._constraints = constraints
         self._analyzed_parameters = (
             [] if analyzed_parameters is None else analyzed_parameters

--- a/tests/test_ax_generators.py
+++ b/tests/test_ax_generators.py
@@ -123,11 +123,12 @@ def test_ax_single_fidelity_int():
         evaluator=ev,
         max_evals=10,
         sim_workers=2,
-        exploration_dir_path="./tests_output/test_ax_single_fidelity",
+        exploration_dir_path="./tests_output/test_ax_single_fidelity_int",
     )
 
     # Get reference to original AxClient.
     ax_client = gen._ax_client
+    assert ax_client.experiment.search_space.parameters["x0"].python_type == int
 
     # Run exploration.
     exploration.run()

--- a/tests/test_ax_generators.py
+++ b/tests/test_ax_generators.py
@@ -246,6 +246,9 @@ def test_ax_single_fidelity_updated_params():
     # Update range of x0 and run 10 evals.
     var1.update_range(-20.0, 0.0)
     gen.update_parameter(var1)
+    # Make sure we have an evaluation in the new range (it currently fails
+    # otherwise).
+    exploration.evaluate_trials([{"x0":-10.0, "x1":10.0}])
     exploration.run(n_evals=10)
     assert all(exploration.history["x0"][-10:] >= -20)
     assert all(exploration.history["x0"][-10:] <= 0.0)

--- a/tests/test_ax_generators.py
+++ b/tests/test_ax_generators.py
@@ -104,6 +104,45 @@ def test_ax_single_fidelity():
     np.save("./tests_output/ax_sf_history", exploration._libe_history.H)
 
 
+def test_ax_single_fidelity_int():
+    """
+    Test that an exploration with a single-fidelity generator runs
+    correctly with an integer parameter.
+    """
+
+    var1 = VaryingParameter("x0", -50.0, 5.0, dtype=int)
+    var2 = VaryingParameter("x1", -5.0, 15.0)
+    obj = Objective("f", minimize=False)
+
+    gen = AxSingleFidelityGenerator(
+        varying_parameters=[var1, var2], objectives=[obj]
+    )
+    ev = FunctionEvaluator(function=eval_func_sf)
+    exploration = Exploration(
+        generator=gen,
+        evaluator=ev,
+        max_evals=10,
+        sim_workers=2,
+        exploration_dir_path="./tests_output/test_ax_single_fidelity",
+    )
+
+    # Get reference to original AxClient.
+    ax_client = gen._ax_client
+
+    # Run exploration.
+    exploration.run()
+
+    # Check that the generator has been updated.
+    assert gen.n_completed_trials == exploration.history.shape[0]
+
+    # Check that the original ax client has been updated.
+    n_ax_trials = ax_client.get_trials_data_frame().shape[0]
+    assert n_ax_trials == exploration.history.shape[0]
+
+    # Check correct variable type.
+    assert exploration.history["x0"].to_numpy().dtype == int
+
+
 def test_ax_single_fidelity_moo():
     """
     Test that an exploration with a multi-objective single-fidelity generator
@@ -570,6 +609,7 @@ def test_ax_service_init():
 
 if __name__ == "__main__":
     test_ax_single_fidelity()
+    test_ax_single_fidelity_int()
     test_ax_single_fidelity_moo()
     test_ax_single_fidelity_fb()
     test_ax_single_fidelity_moo_fb()


### PR DESCRIPTION
Fixes a bug introduced in #150, where the `dtype` of the `VaryingParameters` was not being used by the Ax Service generators. The type was therefore being inferred by Ax, which sometimes would set a float as an int.

It also fixes an issue where parameters with a dtype other than float would crash the exploration.

The tests have been updated to prevent a random crash in the new test introduced in #150.