### PR TITLE
Rename `local_threading` to `threads`

### DIFF
--- a/optimas/explorations/base.py
+++ b/optimas/explorations/base.py
@@ -61,14 +61,14 @@ class Exploration:
         There is no need to provide the `history` path (it will be ignored).
         If `False` (default value), the exploration will raise an error if
         the `exploration_dir_path` already exists.
-    libe_comms :  {'local', 'local_threading', 'mpi'}, optional.
+    libe_comms :  {'local', 'threads', 'mpi'}, optional.
         The communication mode for libEnseble. Determines whether to use
-        Python ``multiprocessing`` (local), ``threading`` (local_threading)
+        Python ``multiprocessing`` (local), ``threading`` (threads)
         or MPI for the communication between the manager and workers.
-        The ``'local_threading'`` mode is only recommended when running in a
+        The ``'threads'`` mode is only recommended when running in a
         Jupyter notebook if the default 'local' mode has issues (this
         can happen especially on Windows and Mac, which use multiprocessing
-        ``spawn``). ``'local_threading'`` only supports ``FunctionEvaluator``s.
+        ``spawn``). ``'threads'`` only supports ``FunctionEvaluator``s.
         If running in ``'mpi'`` mode, the Optimas script should be launched
         with ``mpirun`` or equivalent, for example,
         ``mpirun -np N python myscript.py``. This will launch one
@@ -89,15 +89,16 @@ class Exploration:
         history_save_period: Optional[int] = None,
         exploration_dir_path: Optional[str] = "./exploration",
         resume: Optional[bool] = False,
-        libe_comms: Optional[
-            Literal["local", "local_threading", "mpi"]
-        ] = "local",
+        libe_comms: Optional[Literal["local", "threads", "mpi"]] = "local",
     ) -> None:
-        if libe_comms == "local_threading" and not isinstance(
+        # For backward compatibility, check for old threading name.
+        if libe_comms == "local_threading":
+            libe_comms = "threads"
+        if libe_comms == "threads" and not isinstance(
             evaluator, FunctionEvaluator
         ):
             raise ValueError(
-                "'local_threading' mode is only supported when using a "
+                "'threads' mode is only supported when using a "
                 "`FunctionEvaluator`. Use 'local' mode instead."
             )
         self.generator = generator
@@ -495,7 +496,7 @@ class Exploration:
         libE_specs["dedicated_mode"] = False
         # Set communications and corresponding number of workers.
         libE_specs["comms"] = self.libe_comms
-        if self.libe_comms in ["local", "local_threading"]:
+        if self.libe_comms in ["local", "threads"]:
             libE_specs["nworkers"] = self.sim_workers + 1
         elif self.libe_comms == "mpi":
             # Warn user if openmpi is being used.
@@ -515,7 +516,7 @@ class Exploration:
             raise ValueError(
                 "Communication mode '{}'".format(self.libe_comms)
                 + " not recognized. Possible values are 'local', "
-                + "'local_threading' or 'mpi'."
+                + "'threads' or 'mpi'."
             )
         # Set exploration directory path.
         libE_specs["ensemble_dir_path"] = "evaluations"


### PR DESCRIPTION
Updates the name of the threading communications from `local_threading` to `threads`, as now defined in libEnsemble https://github.com/Libensemble/libensemble/pull/1188. This change preserves backward compatibility with `local_threading`.