### PR TITLE
Fix typo in Maxwell installation instructions

### DIFF
--- a/doc/source/user_guide/installation_maxwell.rst
+++ b/doc/source/user_guide/installation_maxwell.rst
@@ -70,7 +70,7 @@ Install FBPIC:
 .. code::
 
     mamba install cudatoolkit=11.8
-    pip install cupy-cuda118
+    pip install cupy-cuda11x
     pip install fbpic
 
 


### PR DESCRIPTION
Fixes a typo in the name of the cupy package.