### PR TITLE
Log to `stdout`

### DIFF
--- a/optimas/utils/logger.py
+++ b/optimas/utils/logger.py
@@ -30,8 +30,8 @@ def get_logger(name, level=logging.INFO) -> logging.Logger:
         datefmt="%m-%d %H:%M:%S",
     )
 
-    # Add handler to log to standard error.
-    sth = logging.StreamHandler(stream=sys.stderr)
+    # Add handler to log to standard output.
+    sth = logging.StreamHandler(stream=sys.stdout)
     sth.setFormatter(formatter)
     logger.addHandler(sth)
     return logger


### PR DESCRIPTION
Log optimas output to `stdout` instead of `stderr`. This makes it cleaner (it won't be mixed with warnings and logs from other dependencies) and is more in line with the user expectations.