### PR TITLE
Keep trailing newline in template script

### DIFF
--- a/optimas/sim_functions.py
+++ b/optimas/sim_functions.py
@@ -82,7 +82,7 @@ def execute_and_analyze_simulation(
     """Run simulation, handle outcome and analyze results."""
     # Create simulation input file.
     with open(sim_template, "r") as f:
-        template = jinja2.Template(f.read())
+        template = jinja2.Template(f.read(), keep_trailing_newline=True)
     with open(sim_template, "w") as f:
         f.write(template.render(input_values))
 


### PR DESCRIPTION
Fixes a bug where the trailing newline of the template script would be removed when generating the simulation scripts. This was leading to issues with ASTRA simulations.