### PR TITLE
Add evaluation timeout and improve handling of evaluations that failed to launch

### DIFF
--- a/optimas/evaluators/template_evaluator.py
+++ b/optimas/evaluators/template_evaluator.py
@@ -46,6 +46,9 @@ class TemplateEvaluator(Evaluator):
         If the `env_script` loads an MPI different than the one in the optimas
         environment, indicate it here. Possible values are "mpich", "openmpi",
         "aprun", "srun", "jsrun", "msmpi".
+    timeout : float, optional
+        Time in seconds until the evaluation is forcibly terminated. By default
+        ``None`` (i.e., no timeout).
 
     """
 
@@ -59,6 +62,7 @@ class TemplateEvaluator(Evaluator):
         n_gpus: Optional[int] = None,
         env_script: Optional[str] = None,
         env_mpi: Optional[str] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         super().__init__(
             sim_function=run_template_simulation, n_procs=n_procs, n_gpus=n_gpus
@@ -68,6 +72,7 @@ class TemplateEvaluator(Evaluator):
         self.executable = executable
         self.env_script = env_script
         self.env_mpi = env_mpi
+        self.timeout = timeout
         self.sim_files = [] if sim_files is None else sim_files
         self._app_name = "sim"
 
@@ -99,6 +104,7 @@ class TemplateEvaluator(Evaluator):
         sim_specs["user"]["num_gpus"] = self._n_gpus
         sim_specs["user"]["env_script"] = self.env_script
         sim_specs["user"]["env_mpi"] = self.env_mpi
+        sim_specs["user"]["timeout"] = self.timeout
         return sim_specs
 
     def get_libe_specs(self) -> Dict:

--- a/optimas/sim_functions.py
+++ b/optimas/sim_functions.py
@@ -3,17 +3,8 @@
 import jinja2
 import numpy as np
 
-from libensemble.executors.executor import (
-    Executor,
-    TimeoutExpired,
-    ExecutorException,
-)
-from libensemble.message_numbers import (
-    WORKER_DONE,
-    TASK_FAILED,
-    WORKER_KILL_ON_TIMEOUT,
-    CALC_EXCEPTION,
-)
+from libensemble.executors.executor import Executor
+from libensemble.message_numbers import WORKER_DONE, TASK_FAILED
 
 from optimas.utils.logger import get_logger
 
@@ -114,26 +105,8 @@ def execute_and_analyze_simulation(
         env_script=env_script,
         mpi_runner_type=mpi_runner_type,
     )
-    task_launch_failed = False
 
-    # Wait for simulation to complete
-    try:
-        task.wait(timeout=timeout)
-    except TimeoutExpired:
-        task.kill()
-    except ExecutorException:
-        task_launch_failed = True
-
-    # Set calc_status with optional prints.
-    if task_launch_failed:
-        calc_status = CALC_EXCEPTION
-    elif task.finished:
-        if task.state == "FINISHED":
-            calc_status = WORKER_DONE
-        elif task.state == "FAILED":
-            calc_status = TASK_FAILED
-        elif task.state == "USER_KILLED":
-            calc_status = WORKER_KILL_ON_TIMEOUT
+    calc_status = Executor.executor.polling_loop(task, timeout=timeout)
 
     # Data analysis from the last simulation
     if calc_status == WORKER_DONE:

--- a/optimas/sim_functions.py
+++ b/optimas/sim_functions.py
@@ -2,8 +2,17 @@
 import jinja2
 import numpy as np
 
-from libensemble.executors.executor import Executor, TimeoutExpired, ExecutorException
-from libensemble.message_numbers import WORKER_DONE, TASK_FAILED, WORKER_KILL_ON_TIMEOUT, CALC_EXCEPTION
+from libensemble.executors.executor import (
+    Executor,
+    TimeoutExpired,
+    ExecutorException,
+)
+from libensemble.message_numbers import (
+    WORKER_DONE,
+    TASK_FAILED,
+    WORKER_KILL_ON_TIMEOUT,
+    CALC_EXCEPTION,
+)
 
 from optimas.utils.logger import get_logger
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
 ]
 dependencies = [
-    'libensemble @ git+https://github.com/Libensemble/libensemble@develop',
+    'libensemble @ git+https://github.com/Libensemble/libensemble@fixes/various_fixes_optims',
     'jinja2',
     'pandas',
     'mpi4py',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
 ]
 dependencies = [
-    'libensemble @ git+https://github.com/Libensemble/libensemble@fixes/various_fixes_optims',
+    'libensemble @ git+https://github.com/Libensemble/libensemble@develop',
     'jinja2',
     'pandas',
     'mpi4py',

--- a/tests/resources/template_simulation_script.py
+++ b/tests/resources/template_simulation_script.py
@@ -4,9 +4,14 @@ The template takes two parameters x0 and x1 as input
 and stores the result in `result.txt`.
 """
 import os
+import time
 import numpy as np
 
 test_env_var = os.getenv("LIBE_TEST_SUB_ENV_VAR")
+sleep = os.getenv("OPTIMAS_TEST_SLEEP")
+
+if sleep is not None:
+    time.sleep(float(sleep))
 
 # 2D function with multiple minima
 result = -({{x0}} + 10 * np.cos({{x0}})) * ({{x1}} + 5 * np.cos({{x1}}))

--- a/tests/test_template_evaluator.py
+++ b/tests/test_template_evaluator.py
@@ -76,5 +76,53 @@ def test_template_evaluator():
         )
 
 
+def test_template_evaluator_timeout():
+    """Test the evaluation timeout.
+
+    All evaluations will sleep for 20 seconds. This should trigger the 1
+    second timeout set in the `TemplateEvaluator`, causing all evaluations
+    to fail.
+    """
+    # Make evaluations sleep for 20 seconds.
+    os.environ['OPTIMAS_TEST_SLEEP'] = "20"
+
+    # Define variables and objectives.
+    var1 = VaryingParameter("x0", -50.0, 5.0)
+    var2 = VaryingParameter("x1", -5.0, 15.0)
+    obj = Objective("f", minimize=False)
+
+    # Define variables and objectives.
+    gen = RandomSamplingGenerator(
+        varying_parameters=[var1, var2],
+        objectives=[obj],
+    )
+
+    # Create template evaluator with 1s timeout.
+    ev = TemplateEvaluator(
+        sim_template=os.path.join(
+            os.path.abspath(os.path.dirname(__file__)),
+            "resources",
+            "template_simulation_script.py",
+        ),
+        timeout=1,
+    )
+
+    # Create exploration.
+    exploration = Exploration(
+        generator=gen,
+        evaluator=ev,
+        max_evals=10,
+        sim_workers=2,
+        exploration_dir_path="./tests_output/test_template_evaluator_timeout",
+    )
+
+    # Run exploration.
+    exploration.run()
+
+    # Check that no evaluations were successful.
+    assert np.testing.assert_array_equal(exploration.history["f"], 0.)
+
+
 if __name__ == "__main__":
     test_template_evaluator()
+    test_template_evaluator_timeout()

--- a/tests/test_template_evaluator.py
+++ b/tests/test_template_evaluator.py
@@ -120,7 +120,7 @@ def test_template_evaluator_timeout():
     exploration.run()
 
     # Check that no evaluations were successful.
-    assert np.testing.assert_array_equal(exploration.history["f"], 0.0)
+    np.testing.assert_array_equal(exploration.history["f"], 0.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_template_evaluator.py
+++ b/tests/test_template_evaluator.py
@@ -84,7 +84,7 @@ def test_template_evaluator_timeout():
     to fail.
     """
     # Make evaluations sleep for 20 seconds.
-    os.environ['OPTIMAS_TEST_SLEEP'] = "20"
+    os.environ["OPTIMAS_TEST_SLEEP"] = "20"
 
     # Define variables and objectives.
     var1 = VaryingParameter("x0", -50.0, 5.0)
@@ -120,7 +120,7 @@ def test_template_evaluator_timeout():
     exploration.run()
 
     # Check that no evaluations were successful.
-    assert np.testing.assert_array_equal(exploration.history["f"], 0.)
+    assert np.testing.assert_array_equal(exploration.history["f"], 0.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a new `timeout` option to the `TemplateEvaluator` that will kill an evaluation if its runtime reaches this value. It also adds better handling of evaluations that failed to be launched, which are now properly labeled as failed by using the new `polling_loop` from https://github.com/Libensemble/libensemble/pull/1229.