### PR TITLE
Use Python 3.11 on Maxwell

### DIFF
--- a/doc/source/user_guide/installation_maxwell.rst
+++ b/doc/source/user_guide/installation_maxwell.rst
@@ -34,7 +34,7 @@ Create a new environment for optimas
 
 .. code::
 
-    mamba create -n optimas_env python
+    mamba create -n optimas_env python=3.11
 
 
 Activate the environment


### PR DESCRIPTION
Make sure python 3.11 is used on Maxwell, since 3.12 is not yet supported and 3.9 seems to be having issues.