### PR TITLE
Add support for constraints in Ax generators using the Service API

### DIFF
--- a/optimas/core/trial.py
+++ b/optimas/core/trial.py
@@ -96,8 +96,16 @@ class Trial:
 
     @property
     def objective_evaluations(self) -> List[Evaluation]:
-        """Get the list of evaluations (one evaluation per objective)."""
+        """Get list of evaluations (one evaluation per objective)."""
         return [self._mapped_evaluations[obj.name] for obj in self._objectives]
+
+    @property
+    def parameter_evaluations(self) -> List[Evaluation]:
+        """Get list of evaluations (one evaluation per analyzed parameter)."""
+        return [
+            self._mapped_evaluations[par.name]
+            for par in self._analyzed_parameters
+        ]
 
     @property
     def index(self) -> int:

--- a/optimas/generators/ax/service/ax_client.py
+++ b/optimas/generators/ax/service/ax_client.py
@@ -68,7 +68,7 @@ class AxClientGenerator(AxServiceGenerator):
     ):
         varying_parameters = self._get_varying_parameters(ax_client)
         objectives = self._get_objectives(ax_client)
-        self._add_constraint_metrics_to_analyzed_parameters(
+        analyzed_parameters = self._add_constraints_to_analyzed_parameters(
             analyzed_parameters, ax_client
         )
         use_cuda = self._use_cuda(ax_client)
@@ -116,7 +116,7 @@ class AxClientGenerator(AxServiceGenerator):
             objectives.append(obj)
         return objectives
 
-    def _add_constraint_metrics_to_analyzed_parameters(
+    def _add_constraints_to_analyzed_parameters(
         self, analyzed_parameters: List[Parameter], ax_client: AxClient
     ):
         """Add outcome constraints to the list of analyzed parameters.
@@ -127,6 +127,8 @@ class AxClientGenerator(AxServiceGenerator):
         parameters in the optimization log.
         """
         ax_config = ax_client.experiment.optimization_config
+        if ax_config.outcome_constraints and analyzed_parameters is None:
+            analyzed_parameters = []
         for constraint in ax_config.outcome_constraints:
             analyzed_parameters.append(Parameter(name=constraint.metric.name))
 

--- a/optimas/generators/ax/service/ax_client.py
+++ b/optimas/generators/ax/service/ax_client.py
@@ -131,6 +131,7 @@ class AxClientGenerator(AxServiceGenerator):
             analyzed_parameters = []
         for constraint in ax_config.outcome_constraints:
             analyzed_parameters.append(Parameter(name=constraint.metric.name))
+        return analyzed_parameters
 
     def _create_ax_client(self) -> AxClient:
         """Override the base function to simply return the given."""

--- a/optimas/generators/ax/service/ax_client.py
+++ b/optimas/generators/ax/service/ax_client.py
@@ -68,7 +68,9 @@ class AxClientGenerator(AxServiceGenerator):
     ):
         varying_parameters = self._get_varying_parameters(ax_client)
         objectives = self._get_objectives(ax_client)
-        self._add_constraint_metrics_to_analyzed_parameters(analyzed_parameters, ax_client)
+        self._add_constraint_metrics_to_analyzed_parameters(
+            analyzed_parameters, ax_client
+        )
         use_cuda = self._use_cuda(ax_client)
         self._ax_client = ax_client
         super().__init__(

--- a/optimas/generators/ax/service/ax_client.py
+++ b/optimas/generators/ax/service/ax_client.py
@@ -68,7 +68,7 @@ class AxClientGenerator(AxServiceGenerator):
     ):
         varying_parameters = self._get_varying_parameters(ax_client)
         objectives = self._get_objectives(ax_client)
-        self._add_constraints_to_objectives(objectives, ax_client)
+        self._add_constraint_metrics_to_analyzed_parameters(analyzed_parameters, ax_client)
         use_cuda = self._use_cuda(ax_client)
         self._ax_client = ax_client
         super().__init__(
@@ -114,19 +114,19 @@ class AxClientGenerator(AxServiceGenerator):
             objectives.append(obj)
         return objectives
 
-    def _add_constraints_to_objectives(
-        self, objectives: List[Objective], ax_client: AxClient
+    def _add_constraint_metrics_to_analyzed_parameters(
+        self, analyzed_parameters: List[Parameter], ax_client: AxClient
     ):
-        """Add outcome constraints in the AxClient to the list of objectives.
+        """Add outcome constraints to the list of analyzed parameters.
 
         This is currently needed because optimas does not yet have a
         proper definition of constraints. The constraints will be correctly
-        handled and given to the AxClient, but will appear as objectives
-        in the optimization log.
+        handled and given to the AxClient, but will appear as analyzed
+        parameters in the optimization log.
         """
         ax_config = ax_client.experiment.optimization_config
         for constraint in ax_config.outcome_constraints:
-            objectives.append(Objective(name=constraint.metric.name))
+            analyzed_parameters.append(Parameter(name=constraint.metric.name))
 
     def _create_ax_client(self) -> AxClient:
         """Override the base function to simply return the given."""

--- a/optimas/generators/ax/service/base.py
+++ b/optimas/generators/ax/service/base.py
@@ -42,8 +42,9 @@ class AxServiceGenerator(AxGenerator):
         For the latter constraints, any number of arguments is accepted, and
         acceptable operators are ``<=`` and ``>=``.
     outcome_constraints : list of str, optional
-        List of string representation of outcome
-        constraints of form ``"metric_name >= bound"``, like ``"m1 <= 3."``.
+        List of string representation of outcome constraints (i.e., constraints
+        on any of the ``analyzed_parameters``) of form
+        ``"metric_name >= bound"``, like ``"m1 <= 3."``.
     n_init : int, optional
         Number of evaluations to perform during the initialization phase using
         Sobol sampling. If external data is attached to the exploration, the

--- a/optimas/generators/ax/service/base.py
+++ b/optimas/generators/ax/service/base.py
@@ -36,6 +36,14 @@ class AxServiceGenerator(AxGenerator):
     analyzed_parameters : list of Parameter, optional
         List of parameters to analyze at each trial, but which are not
         optimization objectives. By default ``None``.
+    parameter_constraints : list of str, optional
+        List of string representation of parameter
+        constraints, such as "x3 >= x4" or "-x3 + 2*x4 - 3.5*x5 >= 2". For
+        the latter constraints, any number of arguments is accepted, and
+        acceptable operators are "<=" and ">=".
+    outcome_constraints : list of str, optional
+        List of string representation of outcome
+        constraints of form "metric_name >= bound", like "m1 <= 3."
     n_init : int, optional
         Number of evaluations to perform during the initialization phase using
         Sobol sampling. If external data is attached to the exploration, the
@@ -75,6 +83,8 @@ class AxServiceGenerator(AxGenerator):
         varying_parameters: List[VaryingParameter],
         objectives: List[Objective],
         analyzed_parameters: Optional[List[Parameter]] = None,
+        parameter_constraints: Optional[List[str]] = None,
+        outcome_constraints: Optional[List[str]] = None,
         n_init: Optional[int] = 4,
         enforce_n_init: Optional[bool] = False,
         fit_out_of_design: Optional[bool] = False,
@@ -102,6 +112,8 @@ class AxServiceGenerator(AxGenerator):
         self._enforce_n_init = enforce_n_init
         self._fit_out_of_design = fit_out_of_design
         self._fixed_features = None
+        self._parameter_constraints = parameter_constraints
+        self._outcome_constraints = outcome_constraints
         self._ax_client = self._create_ax_client()
 
     def _ask(self, trials: List[Trial]) -> List[Trial]:
@@ -125,12 +137,20 @@ class AxServiceGenerator(AxGenerator):
     def _tell(self, trials: List[Trial]) -> None:
         """Incorporate evaluated trials into Ax client."""
         for trial in trials:
-            objective_eval = {}
+            outcome_evals = {}
+            # Add objective evaluations.
             for ev in trial.objective_evaluations:
-                objective_eval[ev.parameter.name] = (ev.value, ev.sem)
+                outcome_evals[ev.parameter.name] = (ev.value, ev.sem)
+            ax_config = self._ax_client.experiment.optimization_config
+            # Add outcome constraints evaluations.
+            if ax_config.outcome_constraints:
+                ocs = [oc.metric.name for oc in ax_config.outcome_constraints]                
+                for ev in trial.parameter_evaluations:
+                    if ev.parameter.name in ocs:
+                        outcome_evals[ev.parameter.name] = (ev.value, ev.sem)
             try:
                 self._ax_client.complete_trial(
-                    trial_index=trial.ax_trial_id, raw_data=objective_eval
+                    trial_index=trial.ax_trial_id, raw_data=outcome_evals
                 )
             except AttributeError:
                 params = {}
@@ -139,7 +159,7 @@ class AxServiceGenerator(AxGenerator):
                 ):
                     params[var.name] = value
                 _, trial_id = self._ax_client.attach_trial(params)
-                self._ax_client.complete_trial(trial_id, objective_eval)
+                self._ax_client.complete_trial(trial_id, outcome_evals)
 
                 # Since data was given externally, reduce number of
                 # initialization trials.
@@ -173,6 +193,8 @@ class AxServiceGenerator(AxGenerator):
         ax_client.create_experiment(
             parameters=self._create_ax_parameters(),
             objectives=self._create_ax_objectives(),
+            outcome_constraints=self._outcome_constraints,
+            parameter_constraints=self._parameter_constraints,
         )
         return ax_client
 

--- a/optimas/generators/ax/service/base.py
+++ b/optimas/generators/ax/service/base.py
@@ -144,7 +144,7 @@ class AxServiceGenerator(AxGenerator):
             ax_config = self._ax_client.experiment.optimization_config
             # Add outcome constraints evaluations.
             if ax_config.outcome_constraints:
-                ocs = [oc.metric.name for oc in ax_config.outcome_constraints]                
+                ocs = [oc.metric.name for oc in ax_config.outcome_constraints]
                 for ev in trial.parameter_evaluations:
                     if ev.parameter.name in ocs:
                         outcome_evals[ev.parameter.name] = (ev.value, ev.sem)

--- a/optimas/generators/ax/service/base.py
+++ b/optimas/generators/ax/service/base.py
@@ -38,12 +38,12 @@ class AxServiceGenerator(AxGenerator):
         optimization objectives. By default ``None``.
     parameter_constraints : list of str, optional
         List of string representation of parameter
-        constraints, such as "x3 >= x4" or "-x3 + 2*x4 - 3.5*x5 >= 2". For
-        the latter constraints, any number of arguments is accepted, and
-        acceptable operators are "<=" and ">=".
+        constraints, such as ``"x3 >= x4"`` or ``"-x3 + 2*x4 - 3.5*x5 >= 2"``.
+        For the latter constraints, any number of arguments is accepted, and
+        acceptable operators are ``<=`` and ``>=``.
     outcome_constraints : list of str, optional
         List of string representation of outcome
-        constraints of form "metric_name >= bound", like "m1 <= 3."
+        constraints of form ``"metric_name >= bound"``, like ``"m1 <= 3."``.
     n_init : int, optional
         Number of evaluations to perform during the initialization phase using
         Sobol sampling. If external data is attached to the exploration, the

--- a/optimas/generators/ax/service/multi_fidelity.py
+++ b/optimas/generators/ax/service/multi_fidelity.py
@@ -21,6 +21,14 @@ class AxMultiFidelityGenerator(AxServiceGenerator):
     analyzed_parameters : list of Parameter, optional
         List of parameters to analyze at each trial, but which are not
         optimization objectives. By default ``None``.
+    parameter_constraints : list of str, optional
+        List of string representation of parameter
+        constraints, such as "x3 >= x4" or "-x3 + 2*x4 - 3.5*x5 >= 2". For
+        the latter constraints, any number of arguments is accepted, and
+        acceptable operators are "<=" and ">=".
+    outcome_constraints : list of str, optional
+        List of string representation of outcome
+        constraints of form "metric_name >= bound", like "m1 <= 3."
     n_init : int, optional
         Number of evaluations to perform during the initialization phase using
         Sobol sampling. If external data is attached to the exploration, the
@@ -64,6 +72,8 @@ class AxMultiFidelityGenerator(AxServiceGenerator):
         varying_parameters: List[VaryingParameter],
         objectives: List[Objective],
         analyzed_parameters: Optional[List[Parameter]] = None,
+        parameter_constraints: Optional[List[str]] = None,
+        outcome_constraints: Optional[List[str]] = None,
         n_init: Optional[int] = 4,
         enforce_n_init: Optional[bool] = False,
         fit_out_of_design: Optional[bool] = False,
@@ -80,6 +90,8 @@ class AxMultiFidelityGenerator(AxServiceGenerator):
             varying_parameters=varying_parameters,
             objectives=objectives,
             analyzed_parameters=analyzed_parameters,
+            parameter_constraints=parameter_constraints,
+            outcome_constraints=outcome_constraints,
             n_init=n_init,
             enforce_n_init=enforce_n_init,
             fit_out_of_design=fit_out_of_design,

--- a/optimas/generators/ax/service/multi_fidelity.py
+++ b/optimas/generators/ax/service/multi_fidelity.py
@@ -21,14 +21,10 @@ class AxMultiFidelityGenerator(AxServiceGenerator):
     analyzed_parameters : list of Parameter, optional
         List of parameters to analyze at each trial, but which are not
         optimization objectives. By default ``None``.
-    parameter_constraints : list of str, optional
-        List of string representation of parameter
-        constraints, such as ``"x3 >= x4"`` or ``"-x3 + 2*x4 - 3.5*x5 >= 2"``.
-        For the latter constraints, any number of arguments is accepted, and
-        acceptable operators are ``<=`` and ``>=``.
     outcome_constraints : list of str, optional
-        List of string representation of outcome
-        constraints of form ``"metric_name >= bound"``, like ``"m1 <= 3."``.
+        List of string representation of outcome constraints (i.e., constraints
+        on any of the ``analyzed_parameters``) of form
+        ``"metric_name >= bound"``, like ``"m1 <= 3."``.
     n_init : int, optional
         Number of evaluations to perform during the initialization phase using
         Sobol sampling. If external data is attached to the exploration, the
@@ -72,7 +68,6 @@ class AxMultiFidelityGenerator(AxServiceGenerator):
         varying_parameters: List[VaryingParameter],
         objectives: List[Objective],
         analyzed_parameters: Optional[List[Parameter]] = None,
-        parameter_constraints: Optional[List[str]] = None,
         outcome_constraints: Optional[List[str]] = None,
         n_init: Optional[int] = 4,
         enforce_n_init: Optional[bool] = False,
@@ -90,7 +85,6 @@ class AxMultiFidelityGenerator(AxServiceGenerator):
             varying_parameters=varying_parameters,
             objectives=objectives,
             analyzed_parameters=analyzed_parameters,
-            parameter_constraints=parameter_constraints,
             outcome_constraints=outcome_constraints,
             n_init=n_init,
             enforce_n_init=enforce_n_init,

--- a/optimas/generators/ax/service/multi_fidelity.py
+++ b/optimas/generators/ax/service/multi_fidelity.py
@@ -23,12 +23,12 @@ class AxMultiFidelityGenerator(AxServiceGenerator):
         optimization objectives. By default ``None``.
     parameter_constraints : list of str, optional
         List of string representation of parameter
-        constraints, such as "x3 >= x4" or "-x3 + 2*x4 - 3.5*x5 >= 2". For
-        the latter constraints, any number of arguments is accepted, and
-        acceptable operators are "<=" and ">=".
+        constraints, such as ``"x3 >= x4"`` or ``"-x3 + 2*x4 - 3.5*x5 >= 2"``.
+        For the latter constraints, any number of arguments is accepted, and
+        acceptable operators are ``<=`` and ``>=``.
     outcome_constraints : list of str, optional
         List of string representation of outcome
-        constraints of form "metric_name >= bound", like "m1 <= 3."
+        constraints of form ``"metric_name >= bound"``, like ``"m1 <= 3."``.
     n_init : int, optional
         Number of evaluations to perform during the initialization phase using
         Sobol sampling. If external data is attached to the exploration, the

--- a/optimas/generators/ax/service/single_fidelity.py
+++ b/optimas/generators/ax/service/single_fidelity.py
@@ -36,8 +36,9 @@ class AxSingleFidelityGenerator(AxServiceGenerator):
         For the latter constraints, any number of arguments is accepted, and
         acceptable operators are ``<=`` and ``>=``.
     outcome_constraints : list of str, optional
-        List of string representation of outcome
-        constraints of form ``"metric_name >= bound"``, like ``"m1 <= 3."``.
+        List of string representation of outcome constraints (i.e., constraints
+        on any of the ``analyzed_parameters``) of form
+        ``"metric_name >= bound"``, like ``"m1 <= 3."``.
     n_init : int, optional
         Number of evaluations to perform during the initialization phase using
         Sobol sampling. If external data is attached to the exploration, the

--- a/optimas/generators/ax/service/single_fidelity.py
+++ b/optimas/generators/ax/service/single_fidelity.py
@@ -30,6 +30,14 @@ class AxSingleFidelityGenerator(AxServiceGenerator):
     analyzed_parameters : list of Parameter, optional
         List of parameters to analyze at each trial, but which are not
         optimization objectives. By default ``None``.
+    parameter_constraints : list of str, optional
+        List of string representation of parameter
+        constraints, such as "x3 >= x4" or "-x3 + 2*x4 - 3.5*x5 >= 2". For
+        the latter constraints, any number of arguments is accepted, and
+        acceptable operators are "<=" and ">=".
+    outcome_constraints : list of str, optional
+        List of string representation of outcome
+        constraints of form "metric_name >= bound", like "m1 <= 3."
     n_init : int, optional
         Number of evaluations to perform during the initialization phase using
         Sobol sampling. If external data is attached to the exploration, the
@@ -84,6 +92,8 @@ class AxSingleFidelityGenerator(AxServiceGenerator):
         varying_parameters: List[VaryingParameter],
         objectives: List[Objective],
         analyzed_parameters: Optional[List[Parameter]] = None,
+        parameter_constraints: Optional[List[str]] = None,
+        outcome_constraints: Optional[List[str]] = None,
         n_init: Optional[int] = 4,
         enforce_n_init: Optional[bool] = False,
         fit_out_of_design: Optional[bool] = False,
@@ -100,6 +110,8 @@ class AxSingleFidelityGenerator(AxServiceGenerator):
             varying_parameters=varying_parameters,
             objectives=objectives,
             analyzed_parameters=analyzed_parameters,
+            parameter_constraints=parameter_constraints,
+            outcome_constraints=outcome_constraints,
             n_init=n_init,
             enforce_n_init=enforce_n_init,
             fit_out_of_design=fit_out_of_design,

--- a/optimas/generators/ax/service/single_fidelity.py
+++ b/optimas/generators/ax/service/single_fidelity.py
@@ -32,12 +32,12 @@ class AxSingleFidelityGenerator(AxServiceGenerator):
         optimization objectives. By default ``None``.
     parameter_constraints : list of str, optional
         List of string representation of parameter
-        constraints, such as "x3 >= x4" or "-x3 + 2*x4 - 3.5*x5 >= 2". For
-        the latter constraints, any number of arguments is accepted, and
-        acceptable operators are "<=" and ">=".
+        constraints, such as ``"x3 >= x4"`` or ``"-x3 + 2*x4 - 3.5*x5 >= 2"``.
+        For the latter constraints, any number of arguments is accepted, and
+        acceptable operators are ``<=`` and ``>=``.
     outcome_constraints : list of str, optional
         List of string representation of outcome
-        constraints of form "metric_name >= bound", like "m1 <= 3."
+        constraints of form ``"metric_name >= bound"``, like ``"m1 <= 3."``.
     n_init : int, optional
         Number of evaluations to perform during the initialization phase using
         Sobol sampling. If external data is attached to the exploration, the

--- a/tests/test_ax_generators.py
+++ b/tests/test_ax_generators.py
@@ -461,9 +461,12 @@ def test_ax_single_fidelity_with_history():
     var1 = VaryingParameter("x0", -50.0, 5.0)
     var2 = VaryingParameter("x1", -5.0, 15.0)
     obj = Objective("f", minimize=False)
+    p1 = Parameter("p1")
 
     gen = AxSingleFidelityGenerator(
-        varying_parameters=[var1, var2], objectives=[obj]
+        varying_parameters=[var1, var2],
+        objectives=[obj],
+        analyzed_parameters=[p1],
     )
     ev = FunctionEvaluator(function=eval_func_sf)
     exploration = Exploration(

--- a/tests/test_ax_generators.py
+++ b/tests/test_ax_generators.py
@@ -20,7 +20,7 @@ def eval_func_sf(input_params, output_params):
     result = -(x0 + 10 * np.cos(x0)) * (x1 + 5 * np.cos(x1))
     output_params["f"] = result
     if "p1" in output_params.dtype.names:
-        output_params["p1"] = x0 ** 2
+        output_params["p1"] = x0**2
 
 
 def eval_func_sf_moo(input_params, output_params):
@@ -83,7 +83,7 @@ def test_ax_single_fidelity():
         objectives=[obj],
         analyzed_parameters=[p1],
         parameter_constraints=["x0 + x1 <= 10"],
-        outcome_constraints=["p1 <= 30"]
+        outcome_constraints=["p1 <= 30"],
     )
     ev = FunctionEvaluator(function=eval_func_sf)
     exploration = Exploration(
@@ -109,7 +109,7 @@ def test_ax_single_fidelity():
 
     # Check constraints.
     history = exploration.history
-    assert all(history["x0"] + history["x1"] <= 10. + 1e-3)
+    assert all(history["x0"] + history["x1"] <= 10.0 + 1e-3)
     ocs = gen._ax_client.experiment.optimization_config.outcome_constraints
     assert len(ocs) == 1
     assert ocs[0].metric.name == p1.name


### PR DESCRIPTION
Adds the possibility of providing `parameter_constraints` and `outcome_constraints` in the generators that use the Ax Service API.

Example:
```python

var1 = VaryingParameter("x0", -50.0, 5.0)
var2 = VaryingParameter("x1", -5.0, 15.0)
obj = Objective("f", minimize=False)
p1 = Parameter("p1")

gen = AxSingleFidelityGenerator(
    varying_parameters=[var1, var2],
    objectives=[obj],
    analyzed_parameters=[p1],
    parameter_constraints=["x0 + x1 <= 10"],
    outcome_constraints=["p1 <= 30"]
)
```