### PR TITLE
Allow plots in `ExplorationDiagnostics` to be drawn in a grid

### DIFF
--- a/optimas/diagnostics/exploration_diagnostics.py
+++ b/optimas/diagnostics/exploration_diagnostics.py
@@ -161,6 +161,7 @@ class ExplorationDiagnostics:
         use_time_axis: Optional[bool] = False,
         relative_start_time: Optional[bool] = True,
         subplot_spec: Optional[SubplotSpec] = None,
+        **figure_kw
     ) -> None:
         """Plot the values that where reached during the optimization.
 
@@ -181,7 +182,11 @@ class ExplorationDiagnostics:
             Whether the time axis should be relative to the start time
             of the exploration. By default, True.
         subplot_spec: SubplotSpec, optional
-            Spec from which the layout parameters are inherited.
+            The location of the plot in the GridSpec of an existing figure.
+            If not given, a new figure will be created.
+        **figure_kw
+            Additional keyword arguments to pass to `pyplot.figure`. Only used
+            if no ``subplot_spec`` is given.
         """
         if fidelity_parameter is not None:
             fidelity = self.history[fidelity_parameter]
@@ -210,10 +215,12 @@ class ExplorationDiagnostics:
             xlabel = "Number of evaluations"
 
         if subplot_spec is None:
+            fig = plt.figure(**figure_kw)
             gs = GridSpec(1, 1)
         else:
+            fig = plt.gcf()
             gs = GridSpecFromSubplotSpec(1, 1, subplot_spec)
-        ax = plt.subplot(gs[0])
+        ax = fig.add_subplot(gs[0])
         ax.scatter(x, history[objective.name], c=fidelity)
         ax.set_ylabel(objective.name)
         ax.set_xlabel(xlabel)
@@ -233,6 +240,7 @@ class ExplorationDiagnostics:
         show_best_evaluation_indices: Optional[bool] = False,
         show_legend: Optional[bool] = False,
         subplot_spec: Optional[SubplotSpec] = None,
+        **figure_kw
     ) -> None:
         """Plot Pareto front of two optimization objectives.
 
@@ -247,7 +255,11 @@ class ExplorationDiagnostics:
         show_legend : bool, optional
             Whether to show the legend.
         subplot_spec: SubplotSpec, optional
-            Spec from which the layout parameters are inherited.
+            The location of the plot in the GridSpec of an existing figure.
+            If not given, a new figure will be created.
+        **figure_kw
+            Additional keyword arguments to pass to `pyplot.figure`. Only used
+            if no ``subplot_spec`` is given.
         """
         objectives = self._check_pareto_objectives(objectives)
         pareto_evals = self.get_pareto_front_evaluations(objectives)
@@ -258,10 +270,12 @@ class ExplorationDiagnostics:
 
         # Create axes
         if subplot_spec is None:
+            fig = plt.figure(**figure_kw)
             gs = GridSpec(1, 1)
         else:
+            fig = plt.gcf()
             gs = GridSpecFromSubplotSpec(1, 1, subplot_spec)
-        axes = plt.subplot(gs[0])
+        axes = fig.add_subplot(gs[0])
         # Plot all evaluations
         axes.scatter(
             x_data, y_data, s=5, lw=0.0, alpha=0.5, label="All evaluations"
@@ -499,6 +513,7 @@ class ExplorationDiagnostics:
         fidelity_parameter: Optional[str] = None,
         relative_start_time: Optional[bool] = True,
         subplot_spec: Optional[SubplotSpec] = None,
+        **figure_kw
     ) -> None:
         """Plot the timeline of worker utilization.
 
@@ -511,7 +526,11 @@ class ExplorationDiagnostics:
             Whether the time axis should be relative to the start time
             of the exploration. By default, True.
         subplot_spec: SubplotSpec, optional
-            Spec from which the layout parameters are inherited.
+            The location of the plot in the GridSpec of an existing figure.
+            If not given, a new figure will be created.
+        **figure_kw
+            Additional keyword arguments to pass to `pyplot.figure`. Only used
+            if no ``subplot_spec`` is given.
         """
         df = self.history
         df = df[df.sim_id >= 0]
@@ -527,10 +546,12 @@ class ExplorationDiagnostics:
             sim_ended_time = sim_ended_time - df["gen_started_time"].min()
 
         if subplot_spec is None:
+            fig = plt.figure(**figure_kw)
             gs = GridSpec(1, 1)
         else:
+            fig = plt.gcf()
             gs = GridSpecFromSubplotSpec(1, 1, subplot_spec)
-        ax = plt.subplot(gs[0])
+        ax = fig.add_subplot(gs[0])
 
         for i in range(len(df)):
             start = sim_started_time.iloc[i]
@@ -563,6 +584,7 @@ class ExplorationDiagnostics:
         top: Optional[Dict] = None,
         show_legend: Optional[bool] = False,
         subplot_spec: Optional[SubplotSpec] = None,
+        **figure_kw
     ) -> None:
         """Print selected parameters versus evaluation index.
 
@@ -586,7 +608,11 @@ class ExplorationDiagnostics:
         show_legend : bool, optional
             Whether to show the legend.
         subplot_spec: SubplotSpec, optional
-            Spec from which the layout parameters are inherited.
+            The location of the plot in the GridSpec of an existing figure.
+            If not given, a new figure will be created.
+        **figure_kw
+            Additional keyword arguments to pass to `pyplot.figure`. Only used
+            if no ``subplot_spec`` is given.
         """
         # Copy the history DataFrame
         df = self.history.copy()
@@ -635,8 +661,10 @@ class ExplorationDiagnostics:
         # Make figure
         nplots = len(parnames)
         if subplot_spec is None:
+            fig = plt.figure(**figure_kw)
             gs = GridSpec(nplots, 2, width_ratios=[0.8, 0.2], wspace=0.05)
         else:
+            fig = plt.gcf()
             gs = GridSpecFromSubplotSpec(
                 nplots, 2, subplot_spec, width_ratios=[0.8, 0.2], wspace=0.05
             )
@@ -646,7 +674,7 @@ class ExplorationDiagnostics:
         histy_list = []
         for i in range(nplots):
             # Draw scatter plot
-            ax_scatter = plt.subplot(gs[i, 0])
+            ax_scatter = fig.add_subplot(gs[i, 0])
             ax_scatter.grid(color="lightgray", linestyle="dotted")
             yvalues = df[parnames[i]]
             ax_scatter.plot(xvalues, yvalues, "o")
@@ -688,7 +716,7 @@ class ExplorationDiagnostics:
                 )
 
             # Draw projected histogram
-            ax_histy = plt.subplot(gs[i, 1])
+            ax_histy = fig.add_subplot(gs[i, 1])
             ax_histy.grid(color="lightgray", linestyle="dotted")
             ymin, ymax = ax_scatter.get_ylim()
             nbins = 25

--- a/optimas/diagnostics/exploration_diagnostics.py
+++ b/optimas/diagnostics/exploration_diagnostics.py
@@ -10,7 +10,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import matplotlib.pyplot as plt
-from matplotlib.gridspec import GridSpec, GridSpecFromSubplotSpec
+from matplotlib.gridspec import GridSpec, GridSpecFromSubplotSpec, SubplotSpec
 
 from optimas.core import VaryingParameter, Objective, Parameter
 from optimas.generators.base import Generator
@@ -160,7 +160,7 @@ class ExplorationDiagnostics:
         show_trace: Optional[bool] = False,
         use_time_axis: Optional[bool] = False,
         relative_start_time: Optional[bool] = True,
-        subplot_spec: Optional[GridSpec] = None,
+        subplot_spec: Optional[SubplotSpec] = None,
     ) -> None:
         """Plot the values that where reached during the optimization.
 
@@ -232,7 +232,7 @@ class ExplorationDiagnostics:
         objectives: Optional[List[Union[str, Objective]]] = None,
         show_best_evaluation_indices: Optional[bool] = False,
         show_legend: Optional[bool] = False,
-        subplot_spec: Optional[GridSpec] = None,
+        subplot_spec: Optional[SubplotSpec] = None,
     ) -> None:
         """Plot Pareto front of two optimization objectives.
 
@@ -498,7 +498,7 @@ class ExplorationDiagnostics:
         self,
         fidelity_parameter: Optional[str] = None,
         relative_start_time: Optional[bool] = True,
-        subplot_spec: Optional[GridSpec] = None,
+        subplot_spec: Optional[SubplotSpec] = None,
     ) -> None:
         """Plot the timeline of worker utilization.
 
@@ -562,7 +562,7 @@ class ExplorationDiagnostics:
         sort: Optional[Dict] = None,
         top: Optional[Dict] = None,
         show_legend: Optional[bool] = False,
-        subplot_spec: Optional[GridSpec] = None,
+        subplot_spec: Optional[SubplotSpec] = None,
     ) -> None:
         """Print selected parameters versus evaluation index.
 

--- a/optimas/diagnostics/exploration_diagnostics.py
+++ b/optimas/diagnostics/exploration_diagnostics.py
@@ -4,7 +4,7 @@ import shutil
 from warnings import warn
 import pathlib
 import json
-from typing import Optional, List, Tuple, Union
+from typing import Optional, List, Dict, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -539,9 +539,9 @@ class ExplorationDiagnostics:
         self,
         parnames: Optional[list] = None,
         xname: Optional[str] = None,
-        select: Optional[dict] = None,
-        sort: Optional[dict] = None,
-        top: Optional[dict] = None,
+        select: Optional[Dict] = None,
+        sort: Optional[Dict] = None,
+        top: Optional[Dict] = None,
         show_legend: Optional[bool] = False,
         **subplots_kw,
     ) -> None:

--- a/optimas/diagnostics/exploration_diagnostics.py
+++ b/optimas/diagnostics/exploration_diagnostics.py
@@ -635,14 +635,11 @@ class ExplorationDiagnostics:
         # Make figure
         nplots = len(parnames)
         if subplot_spec is None:
-            gs = GridSpec(nplots, 2, 
-                          width_ratios=[0.8, 0.2], 
-                          wspace=0.05)
+            gs = GridSpec(nplots, 2, width_ratios=[0.8, 0.2], wspace=0.05)
         else:
-            gs = GridSpecFromSubplotSpec(nplots, 2,
-                            subplot_spec,
-                            width_ratios=[0.8, 0.2], 
-                            wspace=0.05)
+            gs = GridSpecFromSubplotSpec(
+                nplots, 2, subplot_spec, width_ratios=[0.8, 0.2], wspace=0.05
+            )
 
         # Actual plotting
         ax_histy_list = []

--- a/optimas/utils/other.py
+++ b/optimas/utils/other.py
@@ -67,7 +67,7 @@ def convert_to_dataframe(
         raise ValueError(f"Cannot convert {type(data)} to a pandas dataframe.")
 
 
-def get_df_with_selection(df: pd.DataFrame, select: dict) -> pd.DataFrame:
+def get_df_with_selection(df: pd.DataFrame, select: Dict) -> pd.DataFrame:
     """Return the DataFrame after applying selection criterium.
 
     Parameters

--- a/tests/test_exploration_diagnostics.py
+++ b/tests/test_exploration_diagnostics.py
@@ -80,15 +80,19 @@ def test_exploration_diagnostics():
         for p_i, p_o in zip(gen.analyzed_parameters, diags.analyzed_parameters):
             assert p_i.model_dump_json() == p_o.model_dump_json()
 
+        fig = plt.figure()
         diags.plot_objective(show_trace=True)
         plt.savefig(os.path.join(exploration_dir_path, "optimization.png"))
 
+        fig.clf()
         diags.plot_pareto_front(show_best_evaluation_indices=True)
         plt.savefig(os.path.join(exploration_dir_path, "pareto_front.png"))
 
+        fig.clf()
         diags.plot_worker_timeline()
         plt.savefig(os.path.join(exploration_dir_path, "timeline.png"))
 
+        fig.clf()
         diags.plot_history(top=5, show_legend=True)
         plt.savefig(os.path.join(exploration_dir_path, "history.png"))
 

--- a/tests/test_exploration_diagnostics.py
+++ b/tests/test_exploration_diagnostics.py
@@ -1,6 +1,7 @@
 import os
 
 import numpy as np
+from matplotlib.gridspec import GridSpec
 import matplotlib.pyplot as plt
 import pytest
 
@@ -80,21 +81,28 @@ def test_exploration_diagnostics():
         for p_i, p_o in zip(gen.analyzed_parameters, diags.analyzed_parameters):
             assert p_i.model_dump_json() == p_o.model_dump_json()
 
-        fig = plt.figure()
         diags.plot_objective(show_trace=True)
         plt.savefig(os.path.join(exploration_dir_path, "optimization.png"))
 
-        fig.clf()
         diags.plot_pareto_front(show_best_evaluation_indices=True)
         plt.savefig(os.path.join(exploration_dir_path, "pareto_front.png"))
 
-        fig.clf()
         diags.plot_worker_timeline()
         plt.savefig(os.path.join(exploration_dir_path, "timeline.png"))
 
-        fig.clf()
         diags.plot_history(top=5, show_legend=True)
         plt.savefig(os.path.join(exploration_dir_path, "history.png"))
+
+        fig = plt.figure(figsize=(8, 5))
+        gs = GridSpec(2, 2, wspace=0.4, hspace=0.3, top=0.95, right=0.95)
+        diags.plot_history(top=10, show_legend=True, subplot_spec=gs[:, 0])
+        diags.plot_pareto_front(
+            show_best_evaluation_indices=True,
+            show_legend=True,
+            subplot_spec=gs[0, 1],
+        )
+        diags.plot_worker_timeline(subplot_spec=gs[1, 1])
+        plt.savefig(os.path.join(exploration_dir_path, "combined_plots.png"))
 
         # Check the simulation paths.
         delete_index = 10


### PR DESCRIPTION
Example:

```py
gs = mpl.gridspec.GridSpec(2, 2, wspace=0.2, hspace=0.3)
diags.plot_history(top=10, show_legend=True, subplot_spec=gs[:, 0])
diags.plot_pareto_front(show_best_evaluation_indices=True, show_legend=True, subplot_spec=gs[0, 1])
diags.plot_worker_timeline(subplot_spec=gs[1, 1])
```

![diags](https://github.com/optimas-org/optimas/assets/6736446/21a4202a-f311-497d-9442-f05b94d1586a)
