### PR TITLE
Expose `stdout` and `stderr` filenames to user

### DIFF
--- a/optimas/evaluators/template_evaluator.py
+++ b/optimas/evaluators/template_evaluator.py
@@ -46,6 +46,10 @@ class TemplateEvaluator(Evaluator):
         If the `env_script` loads an MPI different than the one in the optimas
         environment, indicate it here. Possible values are "mpich", "openmpi",
         "aprun", "srun", "jsrun", "msmpi".
+    stdout : str, optional
+        A standard output filename.
+    stderr : str, optional
+        A standard error filename.
 
     """
 
@@ -59,6 +63,8 @@ class TemplateEvaluator(Evaluator):
         n_gpus: Optional[int] = None,
         env_script: Optional[str] = None,
         env_mpi: Optional[str] = None,
+        stdout: Optional[str] = None,
+        stderr: Optional[str] = None,
     ) -> None:
         super().__init__(
             sim_function=run_template_simulation, n_procs=n_procs, n_gpus=n_gpus
@@ -69,6 +75,8 @@ class TemplateEvaluator(Evaluator):
         self.env_script = env_script
         self.env_mpi = env_mpi
         self.sim_files = [] if sim_files is None else sim_files
+        self.stdout = stdout
+        self.stderr = stderr
         self._app_name = "sim"
 
     @property
@@ -99,6 +107,8 @@ class TemplateEvaluator(Evaluator):
         sim_specs["user"]["num_gpus"] = self._n_gpus
         sim_specs["user"]["env_script"] = self.env_script
         sim_specs["user"]["env_mpi"] = self.env_mpi
+        sim_specs["user"]["stdout"] = self.stdout
+        sim_specs["user"]["stderr"] = self.stderr
         return sim_specs
 
     def get_libe_specs(self) -> Dict:

--- a/optimas/sim_functions.py
+++ b/optimas/sim_functions.py
@@ -61,6 +61,8 @@ def run_template_simulation(H, persis_info, sim_specs, libE_info):
             num_gpus=step_specs["num_gpus"],
             env_script=step_specs["env_script"],
             mpi_runner_type=step_specs["env_mpi"],
+            stdout=step_specs["stdout"],
+            stderr=step_specs["stderr"],
         )
         # If a step has failed, do not continue with next steps.
         if calc_status != WORKER_DONE:
@@ -79,6 +81,8 @@ def execute_and_analyze_simulation(
     num_gpus,
     env_script,
     mpi_runner_type,
+    stdout,
+    stderr,
 ):
     """Run simulation, handle outcome and analyze results."""
     # Create simulation input file.
@@ -96,8 +100,8 @@ def execute_and_analyze_simulation(
     task = Executor.executor.submit(
         app_name=app_name,
         app_args=sim_template,
-        stdout="out.txt",
-        stderr="err.txt",
+        stdout=stdout,
+        stderr=stderr,
         num_procs=num_procs,
         num_gpus=num_gpus,
         env_script=env_script,


### PR DESCRIPTION
This PR allows the user to set the names of the standard output and error files. This name was previously hard-coded to `out.txt` and `err.txt`, which caused them to be overwritten when running several simulations with a `ChainEvaluator`.