### PR TITLE
Add conda-forge badge and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![PyPI](https://img.shields.io/pypi/v/optimas)](https://pypi.org/project/optimas/)
+[![Conda Version](https://img.shields.io/conda/vn/conda-forge/optimas.svg)](https://anaconda.org/conda-forge/optimas)
 [![tests badge](https://github.com/optimas-org/optimas/actions/workflows/unix.yml/badge.svg)](https://github.com/optimas-org/optimas/actions)
 [![Documentation Status](https://readthedocs.org/projects/optimas/badge/?version=latest)](https://optimas.readthedocs.io/en/latest/?badge=latest)
 [![DOI](https://zenodo.org/badge/287560975.svg)](https://zenodo.org/badge/latestdoi/287560975)
@@ -39,11 +40,15 @@ Optimas is a Python library designed for highly scalable optimization, from lapt
 
 
 ## Installation
-You can install Optimas from PyPI:
+You can install Optimas from PyPI (recommended):
 ```sh
 pip install optimas
 ```
-Or directly from GitHub:
+from conda-forge:
+```sh
+conda install optimas --channel conda-forge
+```
+or directly from GitHub:
 ```sh
 pip install git+https://github.com/optimas-org/optimas.git
 ```

--- a/doc/source/user_guide/dependencies.rst
+++ b/doc/source/user_guide/dependencies.rst
@@ -22,7 +22,7 @@ See table below for a summary.
 
    * - Generator
      - ``pip install optimas``
-     - ``pip install optimas[all]``
+     - ``pip install 'optimas[all]'``
    * - :class:`~optimas.generators.LineSamplingGenerator`
      - ✅
      - ✅

--- a/doc/source/user_guide/installation_juwels.rst
+++ b/doc/source/user_guide/installation_juwels.rst
@@ -47,7 +47,7 @@ Install ``optimas`` with all dependencies if you plan to do Bayesian optimizatio
 
 .. code::
 
-    pip install optimas[all]
+    pip install 'optimas[all]'
 
 
 Installing FBPIC and Wake-T (optional)

--- a/doc/source/user_guide/installation_local.rst
+++ b/doc/source/user_guide/installation_local.rst
@@ -45,7 +45,7 @@ Installing with **all** dependencies:
 
 .. code::
 
-    pip install optimas[all]
+    pip install 'optimas[all]'
 
 Use this option if you plan to do Bayesian optimization
 (see :ref:`dependencies` for more details).

--- a/doc/source/user_guide/installation_local.rst
+++ b/doc/source/user_guide/installation_local.rst
@@ -50,6 +50,13 @@ Installing with **all** dependencies:
 Use this option if you plan to do Bayesian optimization
 (see :ref:`dependencies` for more details).
 
+Install from conda-forge
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code::
+
+    conda install optimas --channel conda-forge
+
 Install from GitHub
 ~~~~~~~~~~~~~~~~~~~
 This will install the latest development version with all dependencies.

--- a/doc/source/user_guide/installation_maxwell.rst
+++ b/doc/source/user_guide/installation_maxwell.rst
@@ -56,7 +56,7 @@ Install ``optimas`` with all dependencies if you plan to do Bayesian optimizatio
 
 .. code::
 
-    pip install optimas[all]
+    pip install 'optimas[all]'
 
 
 Installing FBPIC and Wake-T (optional)

--- a/doc/source/user_guide/installation_perlmutter.rst
+++ b/doc/source/user_guide/installation_perlmutter.rst
@@ -17,7 +17,7 @@ environment, in which to install *optimas*.
     python3 -m venv $HOME/sw/perlmutter/gpu/venvs/optimas
     source $HOME/sw/perlmutter/gpu/venvs/optimas/bin/activate
 
-    pip install optimas[all]
+    pip install 'optimas[all]'
 
 Running an optimas job
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- Adds the `conda-forge` badge to the readme.
- Updates installation instructions to include the `conda-forge` option.
- `pip install optimas[all]` -> `pip install 'optimas[all]'`. This should work in all terminals.