### PR TITLE
Require `libEnsemble >= 1.2`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
 ]
 dependencies = [
-    'libensemble @ git+https://github.com/Libensemble/libensemble@develop',
+    'libensemble >= 1.2',
     'jinja2',
     'pandas',
     'mpi4py',


### PR DESCRIPTION
Update requirements to latest libEnsemble release in preparation for `v0.4`.