### PR TITLE
Update and speedup tests

### DIFF
--- a/.github/workflows/unix-openmpi.yml
+++ b/.github/workflows/unix-openmpi.yml
@@ -1,4 +1,4 @@
-name: Unix-MPICH
+name: Unix-OpenMPI
 
 on:
   pull_request:
@@ -29,9 +29,9 @@ jobs:
       name: Install dependencies
       run: |
         conda install numpy pandas pytorch cpuonly -c pytorch
-        conda install -c conda-forge mpi4py mpich
+        conda install -c conda-forge mpi4py openmpi
         pip install .[test]
     - shell: bash -l {0}
-      name: Run unit tests with MPICH
+      name: Run unit tests with openMPI
       run: |
         python -m pytest tests/

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -1,7 +1,6 @@
 name: Unix
 
 on:
-  push:
   pull_request:
   # Run daily at midnight (UTC).
   schedule:

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -14,8 +14,8 @@ jobs:
         python-version: [3.9, '3.10', 3.11]
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: actions/checkout@v4
+    - uses: conda-incubator/setup-miniconda@v3
       name: Setup conda
       with:
         auto-update-conda: true


### PR DESCRIPTION
- Separate MPICH and openMPI tests to reduce test runtime.
- Update deprecated actions.
- Run tests only on pull request, and no longer on push.