### PR TITLE
Allow `FunctionEvaluator` to create evaluation dirs

### DIFF
--- a/optimas/diagnostics/exploration_diagnostics.py
+++ b/optimas/diagnostics/exploration_diagnostics.py
@@ -489,7 +489,8 @@ class ExplorationDiagnostics:
             raise ValueError(
                 f"Could not find evaluation directory of trial {trial_index}."
                 "This directory is only created when using a "
-                "`TemplateEvaluator`."
+                "`TemplateEvaluator` or a `FunctionEvaluator` when setting "
+                "`create_evaluation_dirs=True`."
             )
 
     def get_best_evaluation_dir_path(

--- a/optimas/evaluators/function_evaluator.py
+++ b/optimas/evaluators/function_evaluator.py
@@ -17,9 +17,12 @@ class FunctionEvaluator(Evaluator):
 
     """
 
-    def __init__(self, function: Callable) -> None:
+    def __init__(
+        self, function: Callable, create_evaluation_dirs: bool = False
+    ) -> None:
         super().__init__(sim_function=run_function)
         self.function = function
+        self._create_evaluation_dirs = create_evaluation_dirs
 
     def get_sim_specs(
         self,
@@ -35,3 +38,11 @@ class FunctionEvaluator(Evaluator):
         # Add evaluation function to sim_specs.
         sim_specs["user"]["evaluation_func"] = self.function
         return sim_specs
+
+    def get_libe_specs(self) -> Dict:
+        """Get the `libE_specs` for `libEnsemble`."""
+        libE_specs = super().get_libe_specs()
+        # Force libEnsemble to create a directory for each simulation
+        # default value, if not defined
+        libE_specs["sim_dirs_make"] = self._create_evaluation_dirs
+        return libE_specs

--- a/optimas/evaluators/function_evaluator.py
+++ b/optimas/evaluators/function_evaluator.py
@@ -14,6 +14,12 @@ class FunctionEvaluator(Evaluator):
     ----------
     function : callable
         The function to be evaluated.
+    create_evaluation_dirs : bool
+        Whether to create a directory for each evaluation. The directories will
+        be located in `./evaluations` and be named `sim{trial_index}`. When
+        using this option, the current working directory inside the ``function``
+        will be changed to the corresponding evaluation directory.
+        By default, ``False``.
 
     """
 

--- a/optimas/evaluators/function_evaluator.py
+++ b/optimas/evaluators/function_evaluator.py
@@ -48,7 +48,5 @@ class FunctionEvaluator(Evaluator):
     def get_libe_specs(self) -> Dict:
         """Get the `libE_specs` for `libEnsemble`."""
         libE_specs = super().get_libe_specs()
-        # Force libEnsemble to create a directory for each simulation
-        # default value, if not defined
         libE_specs["sim_dirs_make"] = self._create_evaluation_dirs
         return libE_specs

--- a/tests/test_function_evaluator.py
+++ b/tests/test_function_evaluator.py
@@ -2,11 +2,13 @@ import os
 
 import numpy as np
 import matplotlib.pyplot as plt
+import pytest
 
 from optimas.explorations import Exploration
 from optimas.generators import RandomSamplingGenerator
 from optimas.evaluators import FunctionEvaluator
 from optimas.core import VaryingParameter, Objective, Parameter
+from optimas.diagnostics import ExplorationDiagnostics
 
 
 def eval_func(input_params, output_params):
@@ -20,54 +22,75 @@ def eval_func(input_params, output_params):
     plt.figure()
     plt.plot(output_params["p1"][0], output_params["p1"][1])
     output_params["fig"] = plt.gcf()
+    plt.savefig("fig.png")
 
 
 def test_function_evaluator():
     """Test that an exploration runs successfully with a function evaluator."""
-    # Define variables and objectives.
-    var1 = VaryingParameter("x0", -50.0, 5.0)
-    var2 = VaryingParameter("x1", -5.0, 15.0)
-    obj = Objective("f", minimize=False)
-    # Test also more complex analyzed parameters.
-    p0 = Parameter("p0", dtype=(float, (2, 4)))
-    p1 = Parameter("p1", dtype="O")
-    p2 = Parameter("fig", dtype="O")
 
-    # Create generator.
-    gen = RandomSamplingGenerator(
-        varying_parameters=[var1, var2],
-        objectives=[obj],
-        analyzed_parameters=[p0, p1, p2],
-    )
+    create_dirs_options = [False, True]
 
-    # Create function evaluator.
-    ev = FunctionEvaluator(function=eval_func)
+    for create_dirs in create_dirs_options:
+        # Define variables and objectives.
+        var1 = VaryingParameter("x0", -50.0, 5.0)
+        var2 = VaryingParameter("x1", -5.0, 15.0)
+        obj = Objective("f", minimize=False)
+        # Test also more complex analyzed parameters.
+        p0 = Parameter("p0", dtype=(float, (2, 4)))
+        p1 = Parameter("p1", dtype="O")
+        p2 = Parameter("fig", dtype="O")
 
-    # Create exploration.
-    exploration = Exploration(
-        generator=gen,
-        evaluator=ev,
-        max_evals=10,
-        sim_workers=2,
-        exploration_dir_path="./tests_output/test_function_evaluator",
-    )
-
-    # Run exploration.
-    exploration.run()
-
-    # Check that the multidimensional analyzed parameters worked as expected.
-    for p0_data in exploration.history["p0"]:
-        np.testing.assert_array_equal(
-            np.array(p0_data), np.array([[1, 2, 3, 4], [2, 6, 7, 4]])
+        # Create generator.
+        gen = RandomSamplingGenerator(
+            varying_parameters=[var1, var2],
+            objectives=[obj],
+            analyzed_parameters=[p0, p1, p2],
         )
-    for p1_data in exploration.history["p1"]:
-        np.testing.assert_array_equal(
-            np.array(p1_data), np.array([[1, 2, 3, 4], [2, 6, 7, 4]])
+
+        # Create function evaluator.
+        ev = FunctionEvaluator(
+            function=eval_func, create_evaluation_dirs=create_dirs
         )
-    for i, fig in enumerate(exploration.history["fig"]):
-        fig.savefig(
-            os.path.join(exploration.exploration_dir_path, f"test_fig_{i}.png")
+
+        # Create exploration.
+        exploration = Exploration(
+            generator=gen,
+            evaluator=ev,
+            max_evals=10,
+            sim_workers=2,
+            exploration_dir_path="./tests_output/test_function_evaluator",
         )
+
+        # Run exploration.
+        exploration.run()
+
+        # Check that the multidimensional analyzed parameters worked as expected.
+        for p0_data in exploration.history["p0"]:
+            np.testing.assert_array_equal(
+                np.array(p0_data), np.array([[1, 2, 3, 4], [2, 6, 7, 4]])
+            )
+        for p1_data in exploration.history["p1"]:
+            np.testing.assert_array_equal(
+                np.array(p1_data), np.array([[1, 2, 3, 4], [2, 6, 7, 4]])
+            )
+        for i, fig in enumerate(exploration.history["fig"]):
+            fig.savefig(
+                os.path.join(
+                    exploration.exploration_dir_path, f"test_fig_{i}.png"
+                )
+            )
+
+        diags = ExplorationDiagnostics(exploration)
+        for trial_index in diags.history.trial_index:
+            # Check that evaluation folders were created and the data was
+            # stored in them.
+            if create_dirs:
+                trial_dir = diags.get_evaluation_dir_path(trial_index)
+                assert os.path.exists(os.path.join(trial_dir, "fig.png"))
+            # Make sure no folders were created.
+            else:
+                with pytest.raises(ValueError):
+                    diags.get_evaluation_dir_path(trial_index)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a new `create_evaluation_dirs` option to `FunctionEvaluator` so that a sim dir will be created for each evaluation (just like with a `TemplateEvaluator`.