### PR TITLE
Run generator on manager

### DIFF
--- a/optimas/diagnostics/ax_model_manager.py
+++ b/optimas/diagnostics/ax_model_manager.py
@@ -439,7 +439,7 @@ class AxModelManager:
         if range_y[1] is None:
             range_y[1] = experiment.parameters[param_y].upper
 
-        # get grid sample of points where to evalutate the model
+        # get grid sample of points where to evaluate the model
         xaxis = np.linspace(range_x[0], range_x[1], n_points)
         yaxis = np.linspace(range_y[0], range_y[1], n_points)
         X, Y = np.meshgrid(xaxis, yaxis)
@@ -596,7 +596,7 @@ class AxModelManager:
         if range[1] is None:
             range[1] = experiment.parameters[param_name].upper
 
-        # get sample of points where to evalutate the model
+        # get sample of points where to evaluate the model
         sample = {param_name: np.linspace(range[0], range[1], n_points)}
 
         if slice_values == "mid":

--- a/optimas/diagnostics/exploration_diagnostics.py
+++ b/optimas/diagnostics/exploration_diagnostics.py
@@ -615,7 +615,7 @@ class ExplorationDiagnostics:
             or descendingly (False)
             e.g. {'f': False} sort simulations according to f descendingly.
         top: int, optional
-            Highight the 'top' evaluations of every objective.
+            Highlight the 'top' evaluations of every objective.
         show_top_evaluation_indices : bool, optional
             Whether to show the indices of the top evaluations.
         show_legend : bool, optional

--- a/optimas/explorations/base.py
+++ b/optimas/explorations/base.py
@@ -173,14 +173,14 @@ class Exploration:
         n_evals_initial = self.generator.n_evaluated_trials
 
         # Create persis_info.
-        persis_info = add_unique_random_streams({}, self.sim_workers + 2)
+        persis_info = add_unique_random_streams({}, self.sim_workers + 1)
 
         # If specified, allocate dedicated resources for the generator.
         if self.generator.dedicated_resources and self.generator.use_cuda:
             persis_info["gen_resources"] = 1
             persis_info["gen_use_gpus"] = True
         else:
-            self.libE_specs["zero_resource_workers"] = [1]
+            self.libE_specs["zero_resource_workers"] = [0]
 
         if self._n_evals > 0:
             self.libE_specs["reuse_output_dir"] = True
@@ -212,9 +212,6 @@ class Exploration:
 
         # Update history.
         self._libe_history.H = history
-
-        # Update generator with the one received from libE.
-        self.generator._update(persis_info[1]["generator"])
 
         # Update number of evaluation in this exploration.
         n_evals_final = self.generator.n_evaluated_trials
@@ -535,6 +532,8 @@ class Exploration:
     def _set_default_libe_specs(self) -> None:
         """Set default exploration libe_specs."""
         libE_specs = {}
+        # Run generator on manager to avoid copying gen to another process.
+        libE_specs["gen_on_manager"] = True
         # Save H to file every N simulation evaluations
         # default value, if not defined
         libE_specs["save_every_k_sims"] = self.history_save_period
@@ -543,7 +542,7 @@ class Exploration:
         # Set communications and corresponding number of workers.
         libE_specs["comms"] = self.libe_comms
         if self.libe_comms in ["local", "threads"]:
-            libE_specs["nworkers"] = self.sim_workers + 1
+            libE_specs["nworkers"] = self.sim_workers
         elif self.libe_comms == "mpi":
             # Warn user if openmpi is being used.
             # When running with MPI communications, openmpi cannot be used as

--- a/optimas/explorations/base.py
+++ b/optimas/explorations/base.py
@@ -179,8 +179,7 @@ class Exploration:
         if self.generator.dedicated_resources and self.generator.use_cuda:
             persis_info["gen_resources"] = 1
             persis_info["gen_use_gpus"] = True
-        else:
-            self.libE_specs["zero_resource_workers"] = [0]
+            self.libE_specs["num_resource_sets"] = self.sim_workers + 1
 
         if self._n_evals > 0:
             self.libE_specs["reuse_output_dir"] = True

--- a/optimas/explorations/base.py
+++ b/optimas/explorations/base.py
@@ -179,6 +179,7 @@ class Exploration:
         if self.generator.dedicated_resources and self.generator.use_cuda:
             persis_info["gen_resources"] = 1
             persis_info["gen_use_gpus"] = True
+            # Create additional resource set for generator.
             self.libE_specs["num_resource_sets"] = self.sim_workers + 1
 
         if self._n_evals > 0:

--- a/optimas/gen_functions.py
+++ b/optimas/gen_functions.py
@@ -117,8 +117,4 @@ def persistent_generator(H, persis_info, gen_specs, libE_info):
         else:
             number_of_gen_points = 0
 
-    # Add updated generator to `persis_info`.
-    generator._prepare_to_send()
-    persis_info["generator"] = generator
-
     return H_o, persis_info, FINISHED_PERSISTENT_GEN_TAG

--- a/optimas/generators/ax/developer/multitask.py
+++ b/optimas/generators/ax/developer/multitask.py
@@ -463,15 +463,6 @@ class AxMultitaskGenerator(AxGenerator):
             encoder_registry=self._encoder_registry,
         )
 
-    def _prepare_to_send(self) -> None:
-        """Prepare generator to send to another process.
-
-        Delete stored generator run. It can contain pytorch tensors that
-        prevent serialization.
-        """
-        del self.gr_lofi
-        self.gr_lofi = None
-
 
 def max_utility_from_GP(
     n: int, m: TorchModelBridge, gr: GeneratorRun, hifi_task: str

--- a/optimas/generators/ax/service/base.py
+++ b/optimas/generators/ax/service/base.py
@@ -17,7 +17,6 @@ from ax.modelbridge.generation_strategy import (
     GenerationStrategy,
 )
 
-from optimas.utils.other import update_object
 from optimas.core import (
     Objective,
     Trial,
@@ -265,36 +264,6 @@ class AxServiceGenerator(AxGenerator):
             ),
         )
         self._ax_client.save_to_json_file(file_path)
-
-    def _prepare_to_send(self) -> None:
-        """Prepare generator to send to another process.
-
-        Delete the fitted model from the generation strategy. It can contain
-        pytorch tensors that prevent serialization.
-        """
-        generation_strategy = self._ax_client.generation_strategy
-        if generation_strategy._model is not None:
-            del generation_strategy._curr.model_spec._fitted_model
-            generation_strategy._curr.model_spec._fitted_model = None
-            del generation_strategy._model
-            generation_strategy._model = None
-
-    def _update(self, new_generator: Generator) -> None:
-        """Update generator with the attributes of a newer one.
-
-        This method is overrides the base one to make sure that the original
-        AxClient is updated and not simply replaced.
-
-        Parameters
-        ----------
-        new_generator : Generator
-            The newer version of the generator returned in ``persis_info``.
-
-        """
-        original_ax_client = self._ax_client
-        super()._update(new_generator)
-        update_object(original_ax_client, new_generator._ax_client)
-        self._ax_client = original_ax_client
 
     def _update_parameter(self, parameter):
         """Update a parameter from the search space."""

--- a/optimas/generators/ax/service/base.py
+++ b/optimas/generators/ax/service/base.py
@@ -267,6 +267,12 @@ class AxServiceGenerator(AxGenerator):
 
     def _update_parameter(self, parameter):
         """Update a parameter from the search space."""
+        # Delete the fitted model from the generation strategy, otherwise
+        # the parameter won't be updated.
+        generation_strategy = self._ax_client.generation_strategy
+        if generation_strategy._model is not None:
+            del generation_strategy._curr.model_spec._fitted_model
+        # Update parameter.
         parameters = self._create_ax_parameters()
         new_search_space = InstantiationBase.make_search_space(parameters, None)
         self._ax_client.experiment.search_space.update_parameter(

--- a/optimas/generators/base.py
+++ b/optimas/generators/base.py
@@ -577,7 +577,7 @@ class Generator:
             These values should instead be supplied in this method.
 
         """
-        pass
+        return trials
 
     def _tell(self, trials: List[Trial]) -> None:
         """Tell method to be implemented by the Generator subclasses.

--- a/optimas/generators/base.py
+++ b/optimas/generators/base.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 
 from optimas.utils.logger import get_logger
-from optimas.utils.other import update_object, convert_to_dataframe
+from optimas.utils.other import convert_to_dataframe
 from optimas.gen_functions import persistent_generator
 from optimas.core import (
     Objective,
@@ -525,7 +525,6 @@ class Generator:
             Maximum number of evaluations to generate.
 
         """
-        self._prepare_to_send()
         gen_specs = {
             # Generator function.
             "gen_f": self._gen_function,
@@ -566,38 +565,6 @@ class Generator:
         """Get the libEnsemble libe_specs."""
         libE_specs = {}
         return libE_specs
-
-    def _prepare_to_send(self) -> None:
-        """Prepare generator to send to another process.
-
-        This method is necessary because the generator, when given to
-        libEnsemble, is sent to another process (the process of the generator
-        worker) and then sent back to optimas at the end of the run. In order
-        for it to be sent, the generator must be serialized, and sometimes
-        some of the contents of the generator cannot be serialized. The
-        purpose of this method is to take care of the attributes that prevent
-        serialization, and is always called before the generator is sent
-        to/from libEnsemble.
-
-        It must be implemented by the subclasses, if needed.
-        """
-        pass
-
-    def _update(self, new_generator: Generator) -> None:
-        """Update generator with the attributes of a newer one.
-
-        This method is only intended to be used internally by an
-        ``Exploration`` after a run is completed. It is needed because the
-        ``Generator`` given to ``libEnsemble`` is passed as a copy to the
-        generator worker and is therefore not updated during the run.
-
-        Parameters
-        ----------
-        new_generator : Generator
-            The newer version of the generator returned in ``persis_info``.
-
-        """
-        update_object(self, new_generator)
 
     def _ask(self, trials: List[Trial]) -> List[Trial]:
         """Ask method to be implemented by the Generator subclasses.

--- a/optimas/utils/other.py
+++ b/optimas/utils/other.py
@@ -6,25 +6,6 @@ import numpy as np
 import pandas as pd
 
 
-def update_object(object_old: Any, object_new: Any) -> None:
-    """Update the attributes of an object with those from a newer one.
-
-    This method is intended to be used with objects of the same type and that
-    have a `__dict__` attribute.
-
-    Parameters
-    ----------
-    object_old : Any
-        The object to be updated.
-    object_new : Any
-        The object from which to get the updated attributes.
-
-    """
-    assert isinstance(object_new, type(object_old)), "Object types don't match"
-    for key, value in vars(object_new).items():
-        setattr(object_old, key, value)
-
-
 def convert_to_dataframe(
     data: Union[Dict, List[Dict], np.ndarray, pd.DataFrame]
 ) -> pd.DataFrame:

--- a/optimas/utils/other.py
+++ b/optimas/utils/other.py
@@ -1,6 +1,6 @@
 """Definition of other utilities used internally by optimas."""
 
-from typing import Any, Union, List, Dict
+from typing import Union, List, Dict
 
 import numpy as np
 import pandas as pd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
 ]
 dependencies = [
-    'libensemble >= 1.2',
+    'libensemble @ git+https://github.com/Libensemble/libensemble@develop',
     'jinja2',
     'pandas',
     'mpi4py',

--- a/tests/resources/template_simulation_script.py
+++ b/tests/resources/template_simulation_script.py
@@ -23,5 +23,5 @@ with open("result.txt", "w") as f:
         output.append(test_env_var)
     f.writelines(output)
 
-with open('cuda_visible_devices.txt', 'w') as f:
+with open("cuda_visible_devices.txt", "w") as f:
     f.write(os.getenv("CUDA_VISIBLE_DEVICES"))

--- a/tests/resources/template_simulation_script.py
+++ b/tests/resources/template_simulation_script.py
@@ -22,3 +22,6 @@ with open("result.txt", "w") as f:
     if test_env_var is not None:
         output.append(test_env_var)
     f.writelines(output)
+
+with open('cuda_visible_devices.txt', 'w') as f:
+    f.write(os.getenv("CUDA_VISIBLE_DEVICES"))

--- a/tests/resources/template_simulation_script.py
+++ b/tests/resources/template_simulation_script.py
@@ -10,6 +10,7 @@ import numpy as np
 
 test_env_var = os.getenv("LIBE_TEST_SUB_ENV_VAR")
 sleep = os.getenv("OPTIMAS_TEST_SLEEP")
+cuda_visible_devices = os.getenv("CUDA_VISIBLE_DEVICES")
 
 if sleep is not None:
     time.sleep(float(sleep))
@@ -23,5 +24,6 @@ with open("result.txt", "w") as f:
         output.append(test_env_var)
     f.writelines(output)
 
-with open("cuda_visible_devices.txt", "w") as f:
-    f.write(os.getenv("CUDA_VISIBLE_DEVICES"))
+if cuda_visible_devices:
+    with open("cuda_visible_devices.txt", "w") as f:
+        f.write(cuda_visible_devices)

--- a/tests/test_ax_generators.py
+++ b/tests/test_ax_generators.py
@@ -347,7 +347,7 @@ def test_ax_single_fidelity_moo_fb():
 def test_ax_single_fidelity_updated_params():
     """
     Test that an exploration with a single-fidelity generator runs
-    as expected when the varing parameters are updated.
+    as expected when the varying parameters are updated.
     """
     # Prevent trials from failing in this test.
     global trial_count

--- a/tests/test_gpu_resources.py
+++ b/tests/test_gpu_resources.py
@@ -1,0 +1,170 @@
+import os
+from multiprocessing import set_start_method
+
+set_start_method("spawn", force=True)
+
+import numpy as np
+from optimas.core import VaryingParameter, Objective, Parameter
+from optimas.generators import AxSingleFidelityGenerator
+from optimas.evaluators import TemplateEvaluator
+from optimas.explorations import Exploration
+
+
+def analyze_simulation(simulation_directory, output_params):
+    """Read in the visible gpus to the worker."""
+    # Read back result from file
+    with open("cuda_visible_devices.txt") as f:
+        cuda_visible_devices = f.read()
+    with open("result.txt") as f:
+        result = float(f.read())
+    # Fill in output parameters.
+    output_params["f"] = result
+    output_params["cuda_visible_devices"] = cuda_visible_devices
+    return output_params
+
+
+def create_exploration(
+    dedicated_resources,
+    use_cuda,
+    sim_workers,
+    gpus_per_worker,
+    gpu_id=0,
+    exploration_dir_path="./exploration",
+):
+    # Create varying parameters and objectives.
+    var_1 = VaryingParameter("x0", 0.0, 15.0)
+    var_2 = VaryingParameter("x1", 0.0, 15.0)
+    obj = Objective("f", minimize=True)
+    p0 = Parameter("cuda_visible_devices", dtype="U10")
+
+    # Create generator.
+    gen = AxSingleFidelityGenerator(
+        varying_parameters=[var_1, var_2],
+        objectives=[obj],
+        analyzed_parameters=[p0],
+        n_init=4,
+        dedicated_resources=dedicated_resources,
+        use_cuda=use_cuda,
+        gpu_id=gpu_id,
+    )
+
+    # Create evaluator.
+    ev = TemplateEvaluator(
+        sim_template=os.path.join(
+            os.path.abspath(os.path.dirname(__file__)),
+            "resources",
+            "template_simulation_script.py",
+        ),
+        analysis_func=analyze_simulation,
+        n_gpus=gpus_per_worker,
+    )
+
+    # Create exploration.
+    exp = Exploration(
+        generator=gen,
+        evaluator=ev,
+        max_evals=10,
+        sim_workers=sim_workers,
+        run_async=False,
+        exploration_dir_path=exploration_dir_path,
+    )
+
+    # Override automatic resource detection to allow testing GPU assignment
+    # event if there are no GPUs available.
+    exp.libE_specs["resource_info"] = {
+        "cores_on_node": (8, 8),
+        "gpus_on_node": 4,
+    }
+
+    return exp
+
+
+def test_gpu_workers():
+    """Test GPU assignment to simulation workers."""
+    exp = create_exploration(
+        dedicated_resources=False,
+        use_cuda=False,
+        sim_workers=4,
+        gpus_per_worker=1,
+        exploration_dir_path="./tests_output/test_gpu_workers",
+    )
+    exp.run()
+    # Check that all 4 GPUs are used, one per sim worker.
+    np.testing.assert_array_equal(
+        exp.history["cuda_visible_devices"],
+        np.array(exp.history["trial_index"] % 4, dtype=str),
+    )
+
+
+def test_multigpu_workers():
+    """
+    Test GPU assignment to simulation workers, with multiple GPUs per
+    worker.
+    """
+    exp = create_exploration(
+        dedicated_resources=False,
+        use_cuda=False,
+        sim_workers=2,
+        gpus_per_worker=2,
+        exploration_dir_path="./tests_output/test_multigpu_workers",
+    )
+    exp.run()
+    # Check that even and odd trials get their corresponding GPUs.
+    np.testing.assert_array_equal(
+        exp.history.iloc[::2]["cuda_visible_devices"], "0,1"
+    )
+    np.testing.assert_array_equal(
+        exp.history.iloc[1::2]["cuda_visible_devices"], "2,3"
+    )
+
+
+def test_gpu_workers_with_shared_gpu_gen():
+    """
+    Test GPU assignment to simulation workers, with a gen that runs on a
+    shared GPU.
+    """
+    exp = create_exploration(
+        dedicated_resources=False,
+        use_cuda=True,
+        sim_workers=4,
+        gpus_per_worker=1,
+        gpu_id=2,
+        exploration_dir_path="./tests_output/test_gpu_workers_with_shared_gpu_gen",
+    )
+    exp.run()
+    # Check that gen (manager) gets GPU 2.
+    assert os.getenv("CUDA_VISIBLE_DEVICES") == "2"
+    # Check all 4 GPUs are available to the workers.
+    np.testing.assert_array_equal(
+        exp.history["cuda_visible_devices"],
+        np.array(exp.history["trial_index"] % 4, dtype=str),
+    )
+
+
+def test_gpu_workers_with_dedicated_gpu_gen():
+    """
+    Test GPU assignment to simulation workers, with a gen that runs on a
+    dedicated GPU.
+    """
+    exp = create_exploration(
+        dedicated_resources=True,
+        use_cuda=True,
+        sim_workers=3,
+        gpus_per_worker=1,
+        exploration_dir_path="./tests_output/test_gpu_workers_with_dedicated_gpu_gen",
+    )
+    exp.run()
+    # Check that gen (manager) gets GPU 0.
+    assert os.getenv("CUDA_VISIBLE_DEVICES") == "0"
+    # Check only 3 GPUs are available to the workers.
+    np.testing.assert_array_equal(
+        exp.history["cuda_visible_devices"],
+        np.array(exp.history["trial_index"] % 3 + 1, dtype=str),
+    )
+
+
+if __name__ == "__main__":
+    test_gpu_workers()
+    test_multigpu_workers()
+    test_gpu_workers_with_shared_gpu_gen()
+    test_gpu_workers_with_dedicated_gpu_gen()


### PR DESCRIPTION
This PR uses the new `"gen_on_manager"` option from libEnsemble, allowing the generator to run in the same process as the manager. This avoids passing the generator to the worker as a copy, so that the generator that `gen_f` uses is the same instance that was created by the user. This simplifies the code (no need to update the gen in a dirty way after the exploration run) and avoids potentially unexpected behavior that could result from operating on copies of the generator.

Additionally, a new test has been added to check that GPU resource allocation works properly.