### PR TITLE
Fix bug when loading AxClient from json and require `Ax >= 0.3.5`

### DIFF
--- a/doc/environment.yaml
+++ b/doc/environment.yaml
@@ -5,7 +5,7 @@ dependencies:
   - pip
   - pip:
     - -e ..
-    - ax-platform >= 0.3.4
+    - ax-platform >= 0.3.5
     - autodoc_pydantic >= 2.0.1
     - ipykernel
     - matplotlib

--- a/optimas/generators/ax/developer/multitask.py
+++ b/optimas/generators/ax/developer/multitask.py
@@ -23,12 +23,7 @@ from ax.core.observation import ObservationFeatures
 from ax.core.generator_run import GeneratorRun
 from ax.storage.json_store.save import save_experiment
 from ax.storage.metric_registry import register_metric
-
-try:
-    from ax.modelbridge.factory import get_MTGP
-except ImportError:
-    # For Ax >= 0.3.4
-    from ax.modelbridge.factory import get_MTGP_LEGACY as get_MTGP
+from ax.modelbridge.factory import get_MTGP_LEGACY as get_MTGP
 
 from optimas.generators.ax.base import AxGenerator
 from optimas.core import (
@@ -355,20 +350,13 @@ class AxMultitaskGenerator(AxGenerator):
 
             generator_success = True
             while True:
-                if version.parse(ax_version) >= version.parse("0.3.5"):
-                    model_gen_options = {
-                        "optimizer_kwargs": {
-                            "options": {
-                                "init_batch_limit": self.init_batch_limit
-                            }
-                        }
-                    }
-                else:
-                    model_gen_options = {
-                        "optimizer_kwargs": {
+                model_gen_options = {
+                    "optimizer_kwargs": {
+                        "options": {
                             "init_batch_limit": self.init_batch_limit
                         }
                     }
+                }
                 try:
                     # Try to generate the new points.
                     gr = m.gen(

--- a/optimas/generators/ax/developer/multitask.py
+++ b/optimas/generators/ax/developer/multitask.py
@@ -352,9 +352,7 @@ class AxMultitaskGenerator(AxGenerator):
             while True:
                 model_gen_options = {
                     "optimizer_kwargs": {
-                        "options": {
-                            "init_batch_limit": self.init_batch_limit
-                        }
+                        "options": {"init_batch_limit": self.init_batch_limit}
                     }
                 }
                 try:

--- a/optimas/generators/ax/import_error_dummy_generator.py
+++ b/optimas/generators/ax/import_error_dummy_generator.py
@@ -12,5 +12,5 @@ class AxImportErrorDummyGenerator(object):
         raise RuntimeError(
             "You need to install ax-platform, in order "
             "to use Ax-based generators in optimas.\n"
-            "e.g. with `pip install ax-platform >= 0.3.4`"
+            "e.g. with `pip install ax-platform >= 0.3.5`"
         )

--- a/optimas/generators/ax/service/base.py
+++ b/optimas/generators/ax/service/base.py
@@ -171,9 +171,7 @@ class AxServiceGenerator(AxGenerator):
                     current_step = generation_strategy.current_step
                     # Reduce only if there are still Sobol trials left.
                     if current_step.model == Models.SOBOL:
-                        current_step.num_trials -= 1
-                        if version.parse(ax_version) >= version.parse("0.3.5"):
-                            current_step.transition_criteria[0].threshold -= 1
+                        current_step.transition_criteria[0].threshold -= 1
                         generation_strategy._maybe_move_to_next_step()
             finally:
                 if trial.completed:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,11 @@ dynamic = ['version']
 test = [
     'flake8',
     'pytest',
-    'ax-platform >= 0.3.4',
+    'ax-platform >= 0.3.5',
     'matplotlib',
 ]
 all = [
-    'ax-platform >= 0.3.4',
+    'ax-platform >= 0.3.5',
 ]
 
 [project.urls]

--- a/tests/test_ax_generators.py
+++ b/tests/test_ax_generators.py
@@ -1,3 +1,4 @@
+import os
 import threading
 
 import numpy as np
@@ -728,6 +729,17 @@ def test_ax_service_init():
         for k in range(i, n_init - 1):
             assert df["generation_method"][k] == "Sobol"
         df["generation_method"][min(i, n_init)] == "GPEI"
+
+    # Try to load saved client from json. This used to fail when the SOBOL
+    # step was skipped due to n_external > n_init. It is added here to prevent
+    # the issue from coming back.
+    AxClient.load_from_json_file(
+        filepath=os.path.join(
+            exploration.exploration_dir_path,
+            "model_history",
+            "ax_client_at_eval_5.json",
+        )
+    )
 
     # Test single case with `enforce_n_init=True`
     gen = AxSingleFidelityGenerator(


### PR DESCRIPTION
Fixes a bug where an AxClient could not be loaded from a json file because the SOBOL step had `num_trials = 0`. The fix is trivial (single line) if we require Ax >= 0.3.5.