### PR TITLE
Update boundary conditions in WarpX example

### DIFF
--- a/examples/multi_stage/template_simulation_script
+++ b/examples/multi_stage/template_simulation_script
@@ -39,8 +39,8 @@ beam.zinject_plane = 0.0
 # boundary
 boundary.field_hi = none damped
 boundary.field_lo = none damped
-boundary.particle_hi = absorbing absorbing
-boundary.particle_lo = absorbing absorbing
+boundary.particle_hi = none absorbing
+boundary.particle_lo = none absorbing
 
 # diag
 diag.diag_type = Full


### PR DESCRIPTION
The lower boundary for particles and fields in the RZ mode of WarpX have to be set to `none`. This commit updates the input file accordingly.