### PR TITLE
Fix ax-platform version

### DIFF
--- a/doc/environment.yaml
+++ b/doc/environment.yaml
@@ -5,7 +5,7 @@ dependencies:
   - pip
   - pip:
     - -e ..
-    - ax-platform >= 0.4.0
+    - ax-platform == 0.4.0
     - autodoc_pydantic >= 2.0.1
     - ipykernel
     - matplotlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ test = [
     'flake8',
     'pytest',
     'pytest-mpi',
-    'ax-platform >= 0.4.0',
+    'ax-platform == 0.4.0',
     'matplotlib',
 ]
 all = [


### PR DESCRIPTION
Using `ax-platform 0.4.0` instead of `ax-platform 0.4.1` avoids the error `cannot import name 'register_metric' from 'ax.storage.metric_registry'`