### PR TITLE
Use more robust calculation of the emittance.

### DIFF
--- a/examples/multi_stage/analysis_script.py
+++ b/examples/multi_stage/analysis_script.py
@@ -9,9 +9,9 @@ from openpmd_viewer.addons import LpaDiagnostics
 def get_emittance(ts, t):
     """Calculate the beam emittance at the given time step."""
     w, x, ux = ts.get_particle(["w", "x", "ux"], t=t)
-    x2 = np.average( x**2, weights=w)
+    x2 = np.average(x**2, weights=w)
     xu = np.average(x * ux, weights=w)
-    return np.sqrt( x2 * np.average( (ux - xu/x2 * x)**2, weights=w) )
+    return np.sqrt(x2 * np.average((ux - xu / x2 * x) ** 2, weights=w))
 
 
 def analyze_simulation(simulation_directory, output_params):

--- a/examples/multi_stage/analysis_script.py
+++ b/examples/multi_stage/analysis_script.py
@@ -17,6 +17,7 @@ def get_emittance(ts, t):
         xu = np.average(x * ux, weights=w)
         return np.sqrt(x2 * u2 - xu**2)
 
+
 def analyze_simulation(simulation_directory, output_params):
     """Analyze the output of the WarpX simulation.
 

--- a/examples/multi_stage/analysis_script.py
+++ b/examples/multi_stage/analysis_script.py
@@ -9,10 +9,13 @@ from openpmd_viewer.addons import LpaDiagnostics
 def get_emittance(ts, t):
     """Calculate the beam emittance at the given time step."""
     w, x, ux = ts.get_particle(["w", "x", "ux"], t=t)
-    x2 = np.average(x**2, weights=w)
-    xu = np.average(x * ux, weights=w)
-    return np.sqrt(x2 * np.average((ux - xu / x2 * x) ** 2, weights=w))
-
+    if len(w) <= 2:
+        return 0
+    else:
+        x2 = np.average(x**2, weights=w)
+        u2 = np.average(ux**2, weights=w)
+        xu = np.average(x * ux, weights=w)
+        return np.sqrt(x2 * u2 - xu**2)
 
 def analyze_simulation(simulation_directory, output_params):
     """Analyze the output of the WarpX simulation.

--- a/examples/multi_stage/analysis_script.py
+++ b/examples/multi_stage/analysis_script.py
@@ -9,10 +9,9 @@ from openpmd_viewer.addons import LpaDiagnostics
 def get_emittance(ts, t):
     """Calculate the beam emittance at the given time step."""
     w, x, ux = ts.get_particle(["w", "x", "ux"], t=t)
-    x2 = np.average(x**2, weights=w)
-    u2 = np.average(ux**2, weights=w)
+    x2 = np.average( x**2, weights=w)
     xu = np.average(x * ux, weights=w)
-    return np.sqrt(x2 * u2 - xu**2)
+    return np.sqrt( x2 * np.average( (ux - xu/x2 * x)**2, weights=w) )
 
 
 def analyze_simulation(simulation_directory, output_params):


### PR DESCRIPTION
In the issue reported in https://github.com/optimas-org/optimas/issues/236, it turns out that, for some input parameters, the simulation returned on only 2 macroparticles at the end of the acceleration stage. 

In this case, this case, the emittance should be exactly 0, but due to floating-point errors, the quantity `x2*u2 -xu**2` happened to be negative.

This PR checks that the number of particles is bigger than 2, to avoid this type of error