### PR TITLE
Use postponed annotations (PEP 563)

### DIFF
--- a/.github/workflows/unix-noax.yml
+++ b/.github/workflows/unix-noax.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10, 3.11, 3.12]
+        python-version: ['3.10', 3.11, 3.12]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/unix-noax.yml
+++ b/.github/workflows/unix-noax.yml
@@ -1,0 +1,39 @@
+name: Unix-Without-Ax
+
+on:
+  pull_request:
+  # Run daily at midnight (UTC).
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', 3.11]
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: conda-incubator/setup-miniconda@v3
+      name: Setup conda
+      with:
+        auto-update-conda: true
+        activate-environment: testing
+        auto-activate-base: false
+        channels: defaults
+        channel-priority: true
+        python-version: ${{ matrix.python-version }}
+
+    - shell: bash -l {0}
+      name: Install dependencies
+      run: |
+        conda install numpy pandas pytorch cpuonly -c pytorch
+        conda install -c conda-forge mpi4py mpich
+        pip install .[test]
+        pip uninstall --yes ax-platform # Run without Ax
+    - shell: bash -l {0}
+      name: Run unit tests without Ax
+      run: |
+        python -m pytest tests/ --ignore=tests/test_ax_generators.py --ignore=tests/test_ax_model_manager.py  --ignore=tests/test_gpu_resources.py
+        mpirun -np 3 python -m pytest --with-mpi tests/test_grid_sampling_mpi.py

--- a/.github/workflows/unix-noax.yml
+++ b/.github/workflows/unix-noax.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', 3.11]
+        python-version: [3.10, 3.11, 3.12]
 
     steps:
     - uses: actions/checkout@v4

--- a/optimas/utils/ax/ax_model_manager.py
+++ b/optimas/utils/ax/ax_model_manager.py
@@ -1,6 +1,17 @@
 """Contains the definition of the AxModelManager class."""
 
-from typing import Optional, Union, List, Tuple, Dict, Any, Literal
+from __future__ import annotations
+
+from typing import (
+    Optional,
+    Union,
+    List,
+    Tuple,
+    Dict,
+    Any,
+    Literal,
+    TYPE_CHECKING,
+)
 
 import numpy as np
 from numpy.typing import NDArray
@@ -33,6 +44,10 @@ except ImportError:
 
 from optimas.core import VaryingParameter, Objective
 from optimas.utils.other import convert_to_dataframe
+
+if TYPE_CHECKING:
+    from ax.service.ax_client import AxClient
+    from ax.modelbridge.torch import TorchModelBridge
 
 
 class AxModelManager:


### PR DESCRIPTION
One way to prevent failure when ax not present.

Ref:
https://peps.python.org/pep-0563
https://docs.python.org/3/library/typing.html#typing.TYPE_CHECKING
