### PR TITLE
[WIP] Ensure that optimas can be run without Ax

### DIFF
--- a/.github/workflows/unix-noax.yml
+++ b/.github/workflows/unix-noax.yml
@@ -35,5 +35,5 @@ jobs:
     - shell: bash -l {0}
       name: Run unit tests without Ax
       run: |
-        python -m pytest tests/ --ignore=tests/test_ax_generators.py --ignore=tests/test_ax_model_manager.py
+        python -m pytest tests/ --ignore=tests/test_ax_generators.py --ignore=tests/test_ax_model_manager.py  --ignore=tests/test_gpu_resources.py
         mpirun -np 3 python -m pytest --with-mpi tests/test_grid_sampling_mpi.py

--- a/.github/workflows/unix-noax.yml
+++ b/.github/workflows/unix-noax.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10, 3.11, 3.12]
+        python-version: ['3.10', 3.11, 3.12]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/unix-noax.yml
+++ b/.github/workflows/unix-noax.yml
@@ -1,0 +1,39 @@
+name: Unix-Without-Ax
+
+on:
+  pull_request:
+  # Run daily at midnight (UTC).
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', 3.11]
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: conda-incubator/setup-miniconda@v3
+      name: Setup conda
+      with:
+        auto-update-conda: true
+        activate-environment: testing
+        auto-activate-base: false
+        channels: defaults
+        channel-priority: true
+        python-version: ${{ matrix.python-version }}
+
+    - shell: bash -l {0}
+      name: Install dependencies
+      run: |
+        conda install numpy pandas pytorch cpuonly -c pytorch
+        conda install -c conda-forge mpi4py mpich
+        pip install .[test]
+        pip uninstall ax-platform # Run without Ax
+    - shell: bash -l {0}
+      name: Run unit tests without Ax
+      run: |
+        python -m pytest tests/ --ignore=tests/test_ax_generators.py --ignore=tests/test_ax_model_manager.py
+        mpirun -np 3 python -m pytest --with-mpi tests/test_grid_sampling_mpi.py

--- a/.github/workflows/unix-noax.yml
+++ b/.github/workflows/unix-noax.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', 3.11]
+        python-version: [3.10, 3.11, 3.12]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/unix-noax.yml
+++ b/.github/workflows/unix-noax.yml
@@ -31,7 +31,7 @@ jobs:
         conda install numpy pandas pytorch cpuonly -c pytorch
         conda install -c conda-forge mpi4py mpich
         pip install .[test]
-        pip uninstall ax-platform # Run without Ax
+        pip uninstall --yes ax-platform # Run without Ax
     - shell: bash -l {0}
       name: Run unit tests without Ax
       run: |

--- a/optimas/generators/__init__.py
+++ b/optimas/generators/__init__.py
@@ -4,8 +4,8 @@ try:
     from .ax.service.multi_fidelity import AxMultiFidelityGenerator
     from .ax.service.ax_client import AxClientGenerator
     from .ax.developer.multitask import AxMultitaskGenerator
-except ImportError as e:
-    if e.__str__() == "No module named 'ax'":
+except (ImportError, ModuleNotFoundError) as e:
+    if e.__str__().startswith("No module named 'ax"):
         # Replace generators by dummy generators that will
         # raise an error only if the user tries to instantiate them
         # and tell them to install ax-platform

--- a/optimas/utils/ax/ax_model_manager.py
+++ b/optimas/utils/ax/ax_model_manager.py
@@ -29,7 +29,11 @@ try:
 
     ax_installed = True
 except ImportError:
+    from .import_error_dummy_class import AxImportErrorDummyClass
+    AxClient = AxImportErrorDummyClass
+    TorchModelBridge = AxImportErrorDummyClass
     ax_installed = False
+
 
 from optimas.core import VaryingParameter, Objective
 from optimas.utils.other import convert_to_dataframe

--- a/optimas/utils/ax/ax_model_manager.py
+++ b/optimas/utils/ax/ax_model_manager.py
@@ -30,6 +30,7 @@ try:
     ax_installed = True
 except ImportError:
     from .import_error_dummy_class import AxImportErrorDummyClass
+
     AxClient = AxImportErrorDummyClass
     TorchModelBridge = AxImportErrorDummyClass
     ax_installed = False

--- a/optimas/utils/ax/import_error_dummy_class.py
+++ b/optimas/utils/ax/import_error_dummy_class.py
@@ -1,0 +1,15 @@
+"""Contains the definition of dummy class that raises an import error."""
+
+
+class AxImportErrorDummyClass(object):
+    """Class that raises an error when instantiated, telling the user to install ax-platform.
+
+    This class replaces all other Ax-based classes, when Ax is not installed
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        raise RuntimeError(
+            "You need to install ax-platform, in order "
+            "to use Ax-based generators in optimas.\n"
+            "e.g. with `pip install ax-platform > 0.5.0`"
+        )


### PR DESCRIPTION
Close #262

This is because some generators (e.g. grid sampling) do not use `Ax` ; in practice `Ax` can be a large dependency.

This PR adds an automated test that makes sure that `optimas` can run without `Ax`.