### PR TITLE
Make mpi4py optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ or directly from GitHub:
 ```sh
 python -m pip install "optimas[all] @ git+https://github.com/optimas-org/optimas.git"
 ```
-Make sure `mpi4py` is available in your environment before installing optimas. For more details, check out the full [installation guide](https://optimas.readthedocs.io/en/latest/user_guide/installation_local.html). We have also prepared dedicated installation instructions for some HPC systems such as
+
+If you intend to run Optimus with an MPI Runner, make sure `mpi4py` is available in your environment before installing optimas.
+
+For more details, check out the full [installation guide](https://optimas.readthedocs.io/en/latest/user_guide/installation_local.html). We have also prepared dedicated installation instructions for some HPC systems such as
 [JUWELS (JSC)](https://optimas.readthedocs.io/en/latest/user_guide/installation_juwels.html),
 [Maxwell (DESY)](https://optimas.readthedocs.io/en/latest/user_guide/installation_maxwell.html) and
 [Perlmutter (NERSC)](https://optimas.readthedocs.io/en/latest/user_guide/installation_perlmutter.html).

--- a/doc/source/user_guide/dependencies.rst
+++ b/doc/source/user_guide/dependencies.rst
@@ -7,11 +7,13 @@ Optimas relies on the following packages:
 
 * `jinja2 <https://pypi.org/project/jinja2/>`_ - Needed to generate simulation scripts from templates.
 * `libEnsemble <https://pypi.org/project/libensemble/>`_ - The backbone of optimas, orchestrates the concurrent evaluation of simulations, the resource detection and allocation, and the communication between simulations and manager.
-* `mpi4py <https://pypi.org/project/mpi4py/>`_ - Python bindings for MPI. Required for launching parallel simulations.
 * `pandas <https://pypi.org/project/pandas/>`_ - Enable output as pandas DataFrames.
 * `pydantic <https://pypi.org/project/pydantic/>`_ - Input validation and object serialization.
 * (optional) `Ax <https://pypi.org/project/ax-platform/>`_ - Algorithms for Bayesian optimization.
 
+Optional dependencies:
+
+* `mpi4py <https://pypi.org/project/mpi4py/>`_ - Python bindings for MPI. Required for launching parallel simulations.
 
 The installed dependencies will determine which generators are available for use.
 See table below for a summary.

--- a/doc/source/user_guide/installation_local.rst
+++ b/doc/source/user_guide/installation_local.rst
@@ -3,6 +3,8 @@ Installation on a local computer
 
 The recommended approach is to install optimas in a ``conda`` environment.
 
+Optional: If you intend to run Optimus with an MPI Runner, ``mpi4py`` is required.
+
 Install ``mpi4py``
 ~~~~~~~~~~~~~~~~~~
 If your system has already an MPI implementation installed, install ``mpi4py``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     'libensemble >= 1.3.0',
     'jinja2',
     'pandas',
-    'mpi4py',
     'pydantic >= 2.0',
 ]
 dynamic = ['version']
@@ -36,10 +35,12 @@ test = [
     'pytest-mpi',
     'ax-platform >=0.5.0',
     'matplotlib',
+    'mpi4py',
 ]
 all = [
     'ax-platform >=0.5.0',
-    'matplotlib'
+    'matplotlib',
+    'mpi4py',
 ]
 
 [project.urls]


### PR DESCRIPTION
Looking at removing the requirement for mpi4py (making it optional), following user discussions.

An argument for keeping it might be that even if you don't use it, many of the examples including most of the example simulators (every case that uses the template evaluator) uses libEnsemble’s MPI executor and therefore requires an MPI. So we could make MPI a required dependency,  but then might it be just as simple to keep mpi4py required?
