### PR TITLE
Allow `FunctionEvaluator` to redirect `stdout` and `stderr` to a log file

### DIFF
--- a/optimas/evaluators/function_evaluator.py
+++ b/optimas/evaluators/function_evaluator.py
@@ -20,15 +20,23 @@ class FunctionEvaluator(Evaluator):
         using this option, the current working directory inside the ``function``
         will be changed to the corresponding evaluation directory.
         By default, ``False``.
+    redirect_logs_to_file : bool
+        Whether to redirect the logs (stdout and stderr) of the evaluation
+        function to a file (log.out and log.err). This can be useful to keep the
+        logs of the exploration clean, preventing many processes from writing to the
+        terminal at once. If enabled, `create_evaluation_dirs` will be set to `True`.
 
     """
 
     def __init__(
-        self, function: Callable, create_evaluation_dirs: bool = False
+        self, function: Callable, create_evaluation_dirs: bool = False, redirect_logs_to_file: bool = False
     ) -> None:
         super().__init__(sim_function=run_function)
         self.function = function
         self._create_evaluation_dirs = create_evaluation_dirs
+        self._redirect_logs_to_file = redirect_logs_to_file
+        if self._redirect_logs_to_file:
+            self._create_evaluation_dirs = True
 
     def get_sim_specs(
         self,
@@ -43,6 +51,7 @@ class FunctionEvaluator(Evaluator):
         )
         # Add evaluation function to sim_specs.
         sim_specs["user"]["evaluation_func"] = self.function
+        sim_specs["user"]["redirect_logs_to_file"] = self._redirect_logs_to_file
         return sim_specs
 
     def get_libe_specs(self) -> Dict:

--- a/optimas/evaluators/function_evaluator.py
+++ b/optimas/evaluators/function_evaluator.py
@@ -29,7 +29,10 @@ class FunctionEvaluator(Evaluator):
     """
 
     def __init__(
-        self, function: Callable, create_evaluation_dirs: bool = False, redirect_logs_to_file: bool = False
+        self,
+        function: Callable,
+        create_evaluation_dirs: bool = False,
+        redirect_logs_to_file: bool = False,
     ) -> None:
         super().__init__(sim_function=run_function)
         self.function = function

--- a/optimas/sim_functions.py
+++ b/optimas/sim_functions.py
@@ -1,4 +1,5 @@
 """Contains the definition of the simulation functions given to libEnsemble."""
+from contextlib import redirect_stderr, redirect_stdout
 
 import jinja2
 import numpy as np
@@ -122,6 +123,7 @@ def run_function(H, persis_info, sim_specs, libE_info):
     else:
         user_specs = sim_specs["user"]
     evaluation_func = user_specs["evaluation_func"]
+    redirect_logs_to_file = user_specs["redirect_logs_to_file"]
 
     # Prepare the array that is returned to libE
     libE_output = np.zeros(1, dtype=sim_specs["out"])
@@ -130,7 +132,16 @@ def run_function(H, persis_info, sim_specs, libE_info):
             libE_output[name].fill(np.nan)
 
     # Run evaluation.
-    evaluation_func(input_values, libE_output[0])
+    if redirect_logs_to_file:
+        with (
+            open("log.out", "w") as stdout_file,
+            open("log.err", "w") as stderr_file,
+            redirect_stdout(stdout_file),
+            redirect_stderr(stderr_file),
+        ):
+            evaluation_func(input_values, libE_output[0])
+    else:
+        evaluation_func(input_values, libE_output[0])
     calc_status = WORKER_DONE
 
     # If required, fail when the objectives are NaN.

--- a/optimas/sim_functions.py
+++ b/optimas/sim_functions.py
@@ -1,4 +1,5 @@
 """Contains the definition of the simulation functions given to libEnsemble."""
+
 from contextlib import redirect_stderr, redirect_stdout
 
 import jinja2

--- a/tests/test_function_evaluator.py
+++ b/tests/test_function_evaluator.py
@@ -112,7 +112,7 @@ def test_function_evaluator_with_logs():
     var1 = VaryingParameter("x0", -50.0, 5.0)
     var2 = VaryingParameter("x1", -5.0, 15.0)
     obj = Objective("f", minimize=False)
-    
+
     # Create generator.
     gen = RandomSamplingGenerator(
         varying_parameters=[var1, var2],


### PR DESCRIPTION
Currently, when using a `FunctionEvaluator`, the output of the exploration and of every runner gets printed in the same terminal. This results in very messy output.

This PR adds the option of redirectling the logs of the `FunctionEvaluator` to a dedicated file for each worker, similarly to how it works with the `TemplateEvaluator`.

When enabling the new `redirect_logs_to_file` option, the `FunctionEvaluator` will force the use of `sim_dirs_make` so that every worker prints to a log file in a separate `sim` directory.