### PR TITLE
Handle exception during exploration run

### DIFF
--- a/optimas/explorations/base.py
+++ b/optimas/explorations/base.py
@@ -208,26 +208,32 @@ class Exploration:
         # Save exploration parameters to json file.
         self._save_exploration_parameters()
 
-        # Launch exploration with libEnsemble.
-        history, persis_info, flag = libE(
-            sim_specs,
-            gen_specs,
-            exit_criteria,
-            persis_info,
-            self.alloc_specs,
-            self.libE_specs,
-            H0=self._libe_history.H,
-        )
+        try:
+            # Launch exploration with libEnsemble.
+            history, persis_info, flag = libE(
+                sim_specs,
+                gen_specs,
+                exit_criteria,
+                persis_info,
+                self.alloc_specs,
+                self.libE_specs,
+                H0=self._libe_history.H,
+            )
 
-        # Update history.
-        self._libe_history.H = history
+            # Update history.
+            self._libe_history.H = history
 
-        # Update number of evaluation in this exploration.
-        n_evals_final = self.generator.n_evaluated_trials
-        self._n_evals += n_evals_final - n_evals_initial
+            # Update number of evaluation in this exploration.
+            n_evals_final = self.generator.n_evaluated_trials
+            self._n_evals += n_evals_final - n_evals_initial
 
-        # Reset `cwd` to initial value before `libE` was called.
-        os.chdir(cwd)
+        except Exception as e:
+            logger.error(
+                "Exploration stopped due to an exception: {}".format(e)
+            )
+        finally:
+            # Reset `cwd` to initial value before `libE` was called.
+            os.chdir(cwd)
 
     def attach_trials(
         self,

--- a/tests/test_exploration_run_exception.py
+++ b/tests/test_exploration_run_exception.py
@@ -1,0 +1,55 @@
+import os
+
+from optimas.explorations import Exploration
+from optimas.generators import RandomSamplingGenerator
+from optimas.evaluators import FunctionEvaluator
+from optimas.core import VaryingParameter, Objective
+
+
+def eval_func(input_params, output_params):
+    raise ValueError("Exception to break exploration")
+
+
+def test_exception_during_exploration_run():
+    """Test that the Exploration handles exceptions during the run correctly.
+    
+    When using `create_evaluation_dirs=True`, the current working directory
+    will change during exploration and should be restored when `.run` finishes,
+    even if an exception occurs.
+    """
+    # Define variables and objectives.
+    var1 = VaryingParameter("x0", -50.0, 5.0)
+    var2 = VaryingParameter("x1", -5.0, 15.0)
+    obj = Objective("f", minimize=False)
+
+    # Create generator.
+    gen = RandomSamplingGenerator(
+        varying_parameters=[var1, var2],
+        objectives=[obj],
+    )
+
+    # Create function evaluator.
+    ev = FunctionEvaluator(
+        function=eval_func, create_evaluation_dirs=True
+    )
+
+    # Create exploration.
+    exploration = Exploration(
+        generator=gen,
+        evaluator=ev,
+        max_evals=10,
+        sim_workers=2,
+        exploration_dir_path="./tests_output/test_function_evaluator",
+    )
+
+    cwd = os.getcwd()
+
+    # Run exploration without raising an exception.
+    exploration.run()
+
+    # Check that the cwd remains unchanged after a failed run.
+    assert os.getcwd() == cwd
+
+
+if __name__ == "__main__":
+    test_exception_during_exploration_run()

--- a/tests/test_exploration_run_exception.py
+++ b/tests/test_exploration_run_exception.py
@@ -12,7 +12,7 @@ def eval_func(input_params, output_params):
 
 def test_exception_during_exploration_run():
     """Test that the Exploration handles exceptions during the run correctly.
-    
+
     When using `create_evaluation_dirs=True`, the current working directory
     will change during exploration and should be restored when `.run` finishes,
     even if an exception occurs.
@@ -29,9 +29,7 @@ def test_exception_during_exploration_run():
     )
 
     # Create function evaluator.
-    ev = FunctionEvaluator(
-        function=eval_func, create_evaluation_dirs=True
-    )
+    ev = FunctionEvaluator(function=eval_func, create_evaluation_dirs=True)
 
     # Create exploration.
     exploration = Exploration(

--- a/tests/test_exploration_run_exception.py
+++ b/tests/test_exploration_run_exception.py
@@ -37,7 +37,7 @@ def test_exception_during_exploration_run():
         evaluator=ev,
         max_evals=10,
         sim_workers=2,
-        exploration_dir_path="./tests_output/test_function_evaluator",
+        exploration_dir_path="./tests_output/test_exception_during_run",
     )
 
     cwd = os.getcwd()


### PR DESCRIPTION
Make sure `Exploration.run` can handle an exception and that the cwd is restored even when an exception occurs.

This prevents an issue when running in Jupyter notebooks, where if the cell execution is cancelled (of the cell that calls Exploration.run) the cwd not be restored and would require restarting the whole notebook.