### PR TITLE
Update for Ax 1.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,7 @@ repos:
 
 # Autoremoves unused Python imports
 - repo: https://github.com/hadialqattan/pycln
-  rev: v2.5.0
+  rev: v2.6.0
   hooks:
   - id: pycln
     name: pycln (python)

--- a/optimas/generators/ax/developer/multitask.py
+++ b/optimas/generators/ax/developer/multitask.py
@@ -425,9 +425,11 @@ class AxMultitaskGenerator(AxGenerator):
         hifi_objective = AxMetric(name="hifi_metric", lower_is_better=minimize)
         lofi_objective = AxMetric(name="lofi_metric", lower_is_better=minimize)
 
-        # Create optimization config.
+        # Create optimization config. As of Ax 1.3, the first positional
+        # argument to `Objective` is an expression string, so the metric must
+        # be passed explicitly via the `metric` keyword.
         opt_config = OptimizationConfig(
-            objective=AxObjective(hifi_objective, minimize=minimize)
+            objective=AxObjective(metric=hifi_objective, minimize=minimize)
         )
 
         # Create experiment.

--- a/optimas/generators/ax/service/ax_client.py
+++ b/optimas/generators/ax/service/ax_client.py
@@ -3,7 +3,6 @@
 from typing import List, Optional
 
 from ax.service.ax_client import AxClient
-from ax.core.objective import MultiObjective
 from ax.core.types import ComparisonOp
 
 from optimas.core import Parameter
@@ -89,24 +88,25 @@ class AxClientGenerator(AxServiceGenerator):
         for _, p in ax_client.experiment.search_space.parameters.items():
             variables[p.name] = [p.lower, p.upper]
 
-        # Extract objectives from optimization config
+        # Extract objectives from optimization config. As of Ax 1.3,
+        # objectives are expression-based: a (possibly multi-) objective
+        # exposes `metric_names` together with `metric_weights`, where a
+        # negative weight indicates minimization.
         objectives = {}
         ax_objective = ax_client.experiment.optimization_config.objective
-        if isinstance(ax_objective, MultiObjective):
-            ax_objectives = ax_objective.objectives
-        else:
-            ax_objectives = [ax_objective]
-
-        for ax_obj in ax_objectives:
-            obj_type = "MINIMIZE" if ax_obj.minimize else "MAXIMIZE"
-            objectives[ax_obj.metric_names[0]] = obj_type
+        obj_weights = dict(ax_objective.metric_weights)
+        for name, signature in zip(
+            ax_objective.metric_names, ax_objective.metric_signatures
+        ):
+            minimize = obj_weights[signature] < 0
+            objectives[name] = "MINIMIZE" if minimize else "MAXIMIZE"
 
         # Extract constraints from outcome constraints (if any)
         constraints = {}
         ax_config = ax_client.experiment.optimization_config
         if ax_config.outcome_constraints:
             for constraint in ax_config.outcome_constraints:
-                name = constraint.metric.name
+                name = constraint.metric_names[0]
                 if constraint.op == ComparisonOp.LEQ:
                     constraints[name] = ["LESS_THAN", constraint.bound]
                 elif constraint.op == ComparisonOp.GEQ:

--- a/optimas/generators/ax/service/base.py
+++ b/optimas/generators/ax/service/base.py
@@ -286,7 +286,7 @@ class AxServiceGenerator(AxGenerator):
         # Add outcome constraints evaluations.
         ax_config = self._ax_client.experiment.optimization_config
         if ax_config.outcome_constraints:
-            ocs = [oc.metric.name for oc in ax_config.outcome_constraints]
+            ocs = [oc.metric_names[0] for oc in ax_config.outcome_constraints]
             for ev in trial.parameter_evaluations:
                 par_name = ev.parameter.name
                 if par_name in ocs:

--- a/optimas/generators/external.py
+++ b/optimas/generators/external.py
@@ -9,7 +9,7 @@ from .base import Generator
 
 
 class ExternalGenerator(Generator):
-    """Wrap a third-party generator that follows the ``gest-api`` standard:
+    """Wrap a third-party generator that follows the ``gest-api`` standard.
 
     https://github.com/campa-consortium/gest-api
 

--- a/optimas/utils/ax/ax_model_manager.py
+++ b/optimas/utils/ax/ax_model_manager.py
@@ -335,10 +335,17 @@ class AxModelManager:
 
         # get optimum
         if len(self.ax_client.objective_names) > 1:
+            # As of Ax 1.3, a multi-objective is expression-based and exposes
+            # `metric_names`/`metric_signatures` together with `metric_weights`
+            # (a negative weight indicates minimization).
             minimize = None
-            for obj in self.ax_client.objective.objectives:
-                if metric_name == obj.metric_names[0]:
-                    minimize = obj.minimize
+            objective = self.ax_client.objective
+            obj_weights = dict(objective.metric_weights)
+            for name, signature in zip(
+                objective.metric_names, objective.metric_signatures
+            ):
+                if metric_name == name:
+                    minimize = obj_weights[signature] < 0
                     break
             pp = self.ax_client.get_pareto_optimal_parameters(
                 use_model_predictions=use_model_predictions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,11 +35,11 @@ test = [
     'flake8',
     'pytest',
     'pytest-mpi',
-    'ax-platform >=1.0.0',
+    'ax-platform[fully_bayesian] >=1.3.1',
     'matplotlib',
 ]
 all = [
-    'ax-platform >=1.0.0',
+    'ax-platform[fully_bayesian] >=1.3.1',
     'matplotlib'
 ]
 

--- a/tests/test_ax_generators.py
+++ b/tests/test_ax_generators.py
@@ -189,7 +189,7 @@ def test_ax_single_fidelity():
     assert all(history["x0"] + history["x1"] <= 10.0 + 1e-3)
     ocs = gen._ax_client.experiment.optimization_config.outcome_constraints
     assert len(ocs) == 1
-    assert ocs[0].metric.name == "p1"
+    assert ocs[0].metric_names[0] == "p1"
 
     # Save history for later restart test
     np.save("./tests_output/ax_sf_history", exploration._libe_history.H)


### PR DESCRIPTION
Fixes the Ax generator tests that broke against **Ax 1.3.x**. 

Ax 1.3.0 redesigned objectives and constraints to be **expression-based** (removing `Objective.metric`,
`MultiObjective.objectives`, and `OutcomeConstraint.metric`), and Ax 1.3.1 moved the SAASBO fully-Bayesian backend to an optional JAX/NumPyro dependency. 

From Ax 1.3.1, this can be done with `ax-platform[fully_bayesian]`

See https://github.com/facebook/Ax/releases